### PR TITLE
Add metadata and userdata to client

### DIFF
--- a/metadata/client.go
+++ b/metadata/client.go
@@ -1,0 +1,37 @@
+package metadata
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/packethost/packngo"
+)
+
+const (
+	baseUrl = "https://metadata.packet.net"
+)
+
+type Client struct {
+	client *packngo.Client
+
+	Metadata MetadataService
+	Userdata UserdataService
+}
+
+type MetadataService interface {
+	Get() (Metadata, error)
+}
+
+type UserdataService interface {
+	Get() (string, error)
+}
+
+func NewClient(httpClient *http.Client) *Client {
+	c := packngo.NewClient("", "", httpClient)
+	c.BaseURL, _ = url.Parse(baseUrl)
+	return &Client{
+		client:   c,
+		Metadata: &MetadataServiceOp{client: c},
+		Userdata: &UserdataServiceOp{client: c},
+	}
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,72 @@
+package metadata
+
+import (
+	"github.com/packethost/packngo"
+)
+
+const (
+	metadataBasePath = "/metadata"
+)
+
+type Metadata struct {
+	ApiUrl          string          `json:"api_url"`
+	Id              string          `json:"id"`
+	Hostname        string          `json:"hostname"`
+	Iqn             string          `json:"iqn"`
+	OperatingSystem OperatingSystem `json:"operating_system"`
+	Plan            string          `json:"plan"`
+	Facility        string          `json:"facility"`
+	SshKeys         []string        `json:"ssh_keys"`
+	Network         Network         `json:"network"`
+}
+
+type Network struct {
+	Addresses  []Address   `json:"addresses"`
+	Interfaces []Interface `json:"interfaces"`
+}
+
+type Address struct {
+	Href          string    `json:"href"`
+	Gateway       string    `json:"gateway"`
+	Address       string    `json:"address"`
+	Network       string    `json:"network"`
+	Id            string    `json:"id"`
+	AddressFamily int       `json:"address_family"`
+	Netmask       string    `json:"netmask"`
+	Public        bool      `json:"public"`
+	Cidr          int       `json:"cidr"`
+	Management    bool      `json:"management"`
+	Manageable    bool      `json:"manageable"`
+	AssignedTo    Reference `json:"assigned_to"`
+}
+
+type Reference struct {
+	Href string `json:"href"`
+}
+
+type OperatingSystem struct {
+	Version string `json:"version"`
+	Distro  string `json:"distro"`
+	Slug    string `json:"slug"`
+}
+
+type Interface struct {
+	Mac  string `json:"mac"`
+	Name string `json:"name"`
+}
+
+type MetadataServiceOp struct {
+	client *packngo.Client
+}
+
+func (s *MetadataServiceOp) Get() (Metadata, error) {
+	metadata := Metadata{}
+
+	req, err := s.client.NewRequest("GET", metadataBasePath, nil)
+	if err != nil {
+		return metadata, err
+	}
+
+	_, err = s.client.Do(req, &metadata)
+	return metadata, err
+}

--- a/metadata/userdata.go
+++ b/metadata/userdata.go
@@ -1,0 +1,26 @@
+package metadata
+
+import (
+	"bytes"
+
+	"github.com/packethost/packngo"
+)
+
+const (
+	userdataBasePath = "/userdata"
+)
+
+type UserdataServiceOp struct {
+	client *packngo.Client
+}
+
+func (s *UserdataServiceOp) Get() (string, error) {
+	req, err := s.client.NewRequest("GET", userdataBasePath, nil)
+	if err != nil {
+		return "", err
+	}
+
+	buffer := &bytes.Buffer{}
+	_, err = s.client.Do(req, buffer)
+	return buffer.String(), err
+}


### PR DESCRIPTION
I'm marking this as WIP because I'm still working on the RancherOS/Packet integration so not 100% sure this is all working.  So far, so good.  I'll update this to not-WIP when I'm confident everything works here.  Right now just wanted to see if the approach was fine.

This probably a duplicate effort with some of the code in https://github.com/coreos/coreos-cloudinit/blob/master/datasource/metadata/packet/metadata.go but I wanted something more standalone.  In RancherOS we use the core-cloudinit datasources but we can't use the networking stuff because its all systemd specific.  As such I had to write code that interacted with metadata to configure the networking in RancherOS.

Signed-off-by: Darren Shepherd darren@rancher.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/3)
<!-- Reviewable:end -->
