### PR TITLE
Make ipxe_script_url optional in DeviceCreateRequest

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -55,7 +55,7 @@ type DeviceCreateRequest struct {
 	ProjectID     string   `json:"project_id"`
 	UserData      string   `json:"userdata"`
 	Tags          []string `json:"tags"`
-	IPXEScriptUrl string   `json:"ipxe_script_url"`
+	IPXEScriptUrl string   `json:"ipxe_script_url,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {


### PR DESCRIPTION
Fixes error with `#!ipxe` userdata:

    422 only ipxe_script_url or userdata may be used for custom ipxe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/21)
<!-- Reviewable:end -->
