### PR TITLE
Add PublicIPv4SubnetSize to device create request

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -47,15 +47,16 @@ func (d Device) String() string {
 
 // DeviceCreateRequest type used to create a Packet device
 type DeviceCreateRequest struct {
-	HostName      string   `json:"hostname"`
-	Plan          string   `json:"plan"`
-	Facility      string   `json:"facility"`
-	OS            string   `json:"operating_system"`
-	BillingCycle  string   `json:"billing_cycle"`
-	ProjectID     string   `json:"project_id"`
-	UserData      string   `json:"userdata"`
-	Tags          []string `json:"tags"`
-	IPXEScriptUrl string   `json:"ipxe_script_url,omitempty"`
+	HostName             string   `json:"hostname"`
+	Plan                 string   `json:"plan"`
+	Facility             string   `json:"facility"`
+	OS                   string   `json:"operating_system"`
+	BillingCycle         string   `json:"billing_cycle"`
+	ProjectID            string   `json:"project_id"`
+	UserData             string   `json:"userdata"`
+	Tags                 []string `json:"tags"`
+	IPXEScriptUrl        string   `json:"ipxe_script_url,omitempty"`
+	PublicIPv4SubnetSize int      `json:"public_ipv4_subnet_size"`
 }
 
 func (d DeviceCreateRequest) String() string {


### PR DESCRIPTION
Adding the `public_ipv4_subnet_size` option by popular request. The goal is to get this to terraform. More about the option at:

https://help.packet.net/technical/networking/custom-subnet-size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/23)
<!-- Reviewable:end -->
