### PR TITLE
Dismiss empty PublicIPv4SubnetSize in API request

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -57,7 +57,7 @@ type DeviceCreateRequest struct {
 	UserData             string   `json:"userdata"`
 	Tags                 []string `json:"tags"`
 	IPXEScriptUrl        string   `json:"ipxe_script_url,omitempty"`
-	PublicIPv4SubnetSize int      `json:"public_ipv4_subnet_size"`
+	PublicIPv4SubnetSize int      `json:"public_ipv4_subnet_size,omitempty"`
 	AlwaysPXE            bool     `json:"always_pxe,omitempty"`
 }
 


### PR DESCRIPTION
`public_ipv4_subnet_size` is not compulsory, and if defined wihout "omitempty", it defaults to zero. Then, `public_ipv4_subnet_size: 0` is added to the device creation request, which then fails in the Packet API.

This PR just adds omitempty so that the `public_ipv4_subnet_size`  field is skipped when default (int => 0).

It was my fault, sorry!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/25)
<!-- Reviewable:end -->
