### PR TITLE
Provide a 'Device.Update' method to update some of the device info

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -9,6 +9,7 @@ type DeviceService interface {
 	List(ProjectID string) ([]Device, *Response, error)
 	Get(string) (*Device, *Response, error)
 	Create(*DeviceCreateRequest) (*Device, *Response, error)
+	Update(string, *DeviceUpdateRequest) (*Device, *Response, error)
 	Delete(string) (*Response, error)
 	Reboot(string) (*Response, error)
 	PowerOff(string) (*Response, error)
@@ -59,6 +60,17 @@ type DeviceCreateRequest struct {
 	IPXEScriptUrl        string   `json:"ipxe_script_url,omitempty"`
 	PublicIPv4SubnetSize int      `json:"public_ipv4_subnet_size,omitempty"`
 	AlwaysPXE            bool     `json:"always_pxe,omitempty"`
+}
+
+// DeviceUpdateRequest type used to update a Packet device
+type DeviceUpdateRequest struct {
+	HostName      string   `json:"hostname"`
+	Description   string   `json:"description"`
+	UserData      string   `json:"userdata"`
+	Locked        bool     `json:"locked"`
+	Tags          []string `json:"tags"`
+	AlwaysPXE     bool     `json:"always_pxe,omitempty"`
+	IPXEScriptUrl string   `json:"ipxe_script_url,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {
@@ -120,6 +132,24 @@ func (s *DeviceServiceOp) Create(createRequest *DeviceCreateRequest) (*Device, *
 	path := fmt.Sprintf("%s/%s/devices", projectBasePath, createRequest.ProjectID)
 
 	req, err := s.client.NewRequest("POST", path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	device := new(Device)
+	resp, err := s.client.Do(req, device)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return device, resp, err
+}
+
+// Update updates an existing device
+func (s *DeviceServiceOp) Update(deviceID string, updateRequest *DeviceUpdateRequest) (*Device, *Response, error) {
+	path := fmt.Sprintf("%s/%s?include=facility", deviceBasePath, deviceID)
+
+	req, err := s.client.NewRequest("PUT", path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/devices.go
+++ b/devices.go
@@ -39,6 +39,7 @@ type Device struct {
 	Facility      *Facility    `json:"facility,omitempty"`
 	Project       *Project     `json:"project,omitempty"`
 	ProvisionPer  float32      `json:"provisioning_percentage,omitempty"`
+	UserData      string       `json:"userdata",omitempty`
 	IPXEScriptUrl string       `json:"ipxe_script_url,omitempty"`
 	AlwaysPXE     bool         `json:"always_pxe,omitempty"`
 }


### PR DESCRIPTION
This primarily adds a `Update` method to the `Devices` which is implemented via the `PUT` API call as documented [here](https://www.packet.net/developers/api/devices/). A second commit also exposes the `userdata` in the `Device` structure to make debugging easier.

We use this `Update` method in [Linuxkit](https://github.com/linuxkit/linuxkit/pull/2423) to reboot a provisioned machine, potentially with a totally different image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/28)
<!-- Reviewable:end -->
