### PR TITLE
Add facility to IP address reservation requets

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -109,6 +109,7 @@ type IPReservationRequest struct {
 	Type     string `json:"type"`
 	Quantity int    `json:"quantity"`
 	Comments string `json:"comments"`
+	Facility string `json:"facility"`
 }
 
 // IPReservation represent an IP reservation for a single project

--- a/ip.go
+++ b/ip.go
@@ -129,6 +129,7 @@ type IPReservation struct {
 	Created       string              `json:"created_at,omitempty"`
 	Updated       string              `json:"updated_at,omitempty"`
 	Href          string              `json:"href"`
+	Facility      Facility            `json:"facility,omitempty"`
 }
 
 type ipReservationRoot struct {


### PR DESCRIPTION
This PR just adds the faciltiy field to the IP address reservation request, so that the packngo struct (and sent JSON) is OK with: https://www.packet.net/developers/api/ipaddresses/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/29)
<!-- Reviewable:end -->
