### PR TITLE
If we get an abnormal http response and no parseable JSON, return http error

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -28,6 +28,9 @@ func GetMetadata() (*CurrentDevice, error) {
 		*CurrentDevice
 	}
 	if err := json.Unmarshal(b, &result); err != nil {
+		if res.StatusCode >= 400 {
+			return nil, errors.New(res.Status)
+		}
 		return nil, err
 	}
 	if result.Error != "" {


### PR DESCRIPTION
This may happen in case of a 500 error, for example.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/30)
<!-- Reviewable:end -->
