### PR TITLE
Add the CIDR to the metadata structure

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -65,10 +65,10 @@ type AddressInfo struct {
 	Address     net.IP        `json:"address"`
 	NetworkMask net.IP        `json:"netmask"`
 	Gateway     net.IP        `json:"gateway"`
+	NetworkBits int           `json:"cidr"`
 
 	// These are available, but not really needed:
 	//   Network     net.IP `json:"network"`
-	//   NetworkBits int    `json:"cidr"`
 }
 
 type BondingMode int


### PR DESCRIPTION
I am passing the addresses to the vishvananda/netlink Go library
which wants an address with CIDR for parsing, so having this is
much more convenient than dealing with the netmask.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/31)
<!-- Reviewable:end -->
