### PR TITLE
refactor of IP service, add ip_test, add projects_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Committing
 ----------
 
 Before committing, it's a good idea to run `gofmt -w *.go`. ([gofmt](https://golang.org/cmd/gofmt/))
+
+Acceptance Tests
+----------------
+
+If you want to run tests against the actual Packet API, you must set envvar `PACKET_TEST_ACTUAL_API` to non-empty string for the `go test` run, e.g.
+
+```
+$ PACKET_TEST_ACTUAL_API=1 go test -v
+```

--- a/devices.go
+++ b/devices.go
@@ -24,24 +24,24 @@ type devicesRoot struct {
 
 // Device represents a Packet device
 type Device struct {
-	ID            string       `json:"id"`
-	Href          string       `json:"href,omitempty"`
-	Hostname      string       `json:"hostname,omitempty"`
-	State         string       `json:"state,omitempty"`
-	Created       string       `json:"created_at,omitempty"`
-	Updated       string       `json:"updated_at,omitempty"`
-	Locked        bool         `json:"locked,omitempty"`
-	BillingCycle  string       `json:"billing_cycle,omitempty"`
-	Tags          []string     `json:"tags,omitempty"`
-	Network       []*IPAddress `json:"ip_addresses"`
-	OS            *OS          `json:"operating_system,omitempty"`
-	Plan          *Plan        `json:"plan,omitempty"`
-	Facility      *Facility    `json:"facility,omitempty"`
-	Project       *Project     `json:"project,omitempty"`
-	ProvisionPer  float32      `json:"provisioning_percentage,omitempty"`
-	UserData      string       `json:"userdata",omitempty`
-	IPXEScriptUrl string       `json:"ipxe_script_url,omitempty"`
-	AlwaysPXE     bool         `json:"always_pxe,omitempty"`
+	ID            string                 `json:"id"`
+	Href          string                 `json:"href,omitempty"`
+	Hostname      string                 `json:"hostname,omitempty"`
+	State         string                 `json:"state,omitempty"`
+	Created       string                 `json:"created_at,omitempty"`
+	Updated       string                 `json:"updated_at,omitempty"`
+	Locked        bool                   `json:"locked,omitempty"`
+	BillingCycle  string                 `json:"billing_cycle,omitempty"`
+	Tags          []string               `json:"tags,omitempty"`
+	Network       []*IPAddressAssignment `json:"ip_addresses"`
+	OS            *OS                    `json:"operating_system,omitempty"`
+	Plan          *Plan                  `json:"plan,omitempty"`
+	Facility      *Facility              `json:"facility,omitempty"`
+	Project       *Project               `json:"project,omitempty"`
+	ProvisionPer  float32                `json:"provisioning_percentage,omitempty"`
+	UserData      string                 `json:"userdata",omitempty`
+	IPXEScriptUrl string                 `json:"ipxe_script_url,omitempty"`
+	AlwaysPXE     bool                   `json:"always_pxe,omitempty"`
 }
 
 func (d Device) String() string {

--- a/ip.go
+++ b/ip.go
@@ -116,6 +116,9 @@ func (i *DeviceIPServiceOp) Assign(deviceID string, assignRequest *AddressStruct
 	path := fmt.Sprintf("%s/%s%s", deviceBasePath, deviceID, ipBasePath)
 
 	req, err := i.client.NewRequest("POST", path, assignRequest)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	ipa := new(IPAddressAssignment)
 	resp, err := i.client.Do(req, ipa)

--- a/ip.go
+++ b/ip.go
@@ -216,7 +216,7 @@ func (i *ProjectIPServiceOp) GetByCIDR(projectID, cidr string) (*IPAddressReserv
 func (i *ProjectIPServiceOp) Request(projectID string, ipReservationReq *IPReservationRequest) (*AddressStruct, *Response, error) {
 	path := fmt.Sprintf("%s/%s%s", projectBasePath, projectID, ipBasePath)
 
-	req, err := i.client.NewRequest("POST", path, &ipReservationReq)
+	req, err := i.client.NewRequest("POST", path, ipReservationReq)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/ip.go
+++ b/ip.go
@@ -1,39 +1,76 @@
 package packngo
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 const ipBasePath = "/ips"
 
 // IPService interface defines available IP methods
 type IPService interface {
-	Assign(deviceID string, assignRequest *IPAddressAssignRequest) (*IPAddress, *Response, error)
-	Unassign(ipAddressID string) (*Response, error)
-	Get(ipAddressID string) (*IPAddress, *Response, error)
+	Assign(deviceID string, assignRequest *AddressField) (*IPAddressAssignment, *Response, error)
+	Unassign(assignmentID string) (*Response, error)
+	GetReservation(reservationID string) (*IPAddressReservation, *Response, error)
+	GetReservationByCIDR(projectID, cidrString string) (*IPAddressReservation, *Response, error)
+	GetAssignment(assignmentID string) (*IPAddressAssignment, *Response, error)
+	ListReservations(projectID string) ([]IPAddressReservation, *Response, error)
+	RequestReservation(projectID string, ipReservationReq *IPReservationRequest) (*AddressField, *Response, error)
+	RemoveReservation(ipReservationID string) (*Response, error)
+	GetAvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error)
 }
 
-// IPAddress represents a ip address
-type IPAddress struct {
-	ID            string            `json:"id"`
-	Address       string            `json:"address"`
-	Gateway       string            `json:"gateway"`
-	Network       string            `json:"network"`
-	AddressFamily int               `json:"address_family"`
-	Netmask       string            `json:"netmask"`
-	Public        bool              `json:"public"`
-	Cidr          int               `json:"cidr"`
-	AssignedTo    map[string]string `json:"assigned_to"`
-	Created       string            `json:"created_at,omitempty"`
-	Updated       string            `json:"updated_at,omitempty"`
-	Href          string            `json:"href"`
-	Facility      Facility          `json:"facility,omitempty"`
+type ipAddressCommon struct {
+	ID            string `json:"id"`
+	Address       string `json:"address"`
+	Gateway       string `json:"gateway"`
+	Network       string `json:"network"`
+	AddressFamily int    `json:"address_family"`
+	Netmask       string `json:"netmask"`
+	Public        bool   `json:"public"`
+	Cidr          int    `json:"cidr"`
+	Created       string `json:"created_at,omitempty"`
+	Updated       string `json:"updated_at,omitempty"`
+	Href          string `json:"href"`
 }
 
-// IPAddressAssignRequest represents the body if a ip assign request
-type IPAddressAssignRequest struct {
+// IPAddressReservation is created when user sends IP reservation request for his/her project (considering it's within quota).
+type IPAddressReservation struct {
+	ipAddressCommon
+	Assignments []Href   `json:"assignments"`
+	Facility    Facility `json:"facility,omitempty"`
+	Available   string   `json:"available"`
+	Addon       bool     `json:"addon"`
+	Bill        bool     `json:"bill"`
+}
+
+// AvailableResponse is a type for listing of avaialable addresses from a reserved block.
+type AvailableResponse struct {
+	Available []string `json:"available"`
+}
+
+// AvailableRequest is a type for listing available addresses from a reserved block.
+type AvailableRequest struct {
+	Cidr int `json:"cidr"`
+}
+
+// IPAddressAssignment is created when an IP address from reservation block is assigned to a device.
+type IPAddressAssignment struct {
+	ipAddressCommon
+	AssignedTo Href `json:"assignments"`
+}
+
+// AddressField is a type for request/response with dict of type {"address": ... }
+type AddressField struct {
 	Address string `json:"address"`
 }
 
-func (i IPAddress) String() string {
+func (i IPAddressReservation) String() string {
+	return Stringify(i)
+}
+
+func (i IPAddressAssignment) String() string {
 	return Stringify(i)
 }
 
@@ -42,102 +79,48 @@ type IPServiceOp struct {
 	client *Client
 }
 
-// Get returns IpAddress by ID
-func (i *IPServiceOp) Get(ipAddressID string) (*IPAddress, *Response, error) {
-	path := fmt.Sprintf("%s/%s", ipBasePath, ipAddressID)
+// GetReservation returns reservation by ID
+func (i *IPServiceOp) GetReservation(reservationID string) (*IPAddressReservation, *Response, error) {
+	path := fmt.Sprintf("%s/%s", ipBasePath, reservationID)
 
 	req, err := i.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ip := new(IPAddress)
-	resp, err := i.client.Do(req, ip)
+	ipr := new(IPAddressReservation)
+	resp, err := i.client.Do(req, ipr)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ip, resp, err
+	return ipr, resp, err
 }
 
-// Unassign unassigns an IP address record. This will remove the relationship between an IP
-// and the device and will make the IP address available to be assigned to another device.
-func (i *IPServiceOp) Unassign(ipAddressID string) (*Response, error) {
-	path := fmt.Sprintf("%s/%s", ipBasePath, ipAddressID)
+// GetAssignment returns assignment by ID
+func (i *IPServiceOp) GetAssignment(assignmentID string) (*IPAddressAssignment, *Response, error) {
+	path := fmt.Sprintf("%s/%s", ipBasePath, assignmentID)
 
-	req, err := i.client.NewRequest("DELETE", path, nil)
+	req, err := i.client.NewRequest("GET", path, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	resp, err := i.client.Do(req, nil)
-	return resp, err
-}
-
-// Assign assigns an IP address to a device. The IP address must be in one of the IP ranges assigned to the device’s project.
-func (i *IPServiceOp) Assign(deviceID string, assignRequest *IPAddressAssignRequest) (*IPAddress, *Response, error) {
-	path := fmt.Sprintf("%s/%s%s", deviceBasePath, deviceID, ipBasePath)
-
-	req, err := i.client.NewRequest("POST", path, assignRequest)
-
-	ip := new(IPAddress)
-	resp, err := i.client.Do(req, ip)
+	ipa := new(IPAddressAssignment)
+	resp, err := i.client.Do(req, ipa)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ip, resp, err
-}
-
-// IP RESERVATIONS API
-
-// IPReservationService interface defines available IPReservation methods
-type IPReservationService interface {
-	List(projectID string) ([]IPReservation, *Response, error)
-	RequestMore(projectID string, ipReservationReq *IPReservationRequest) (*IPReservation, *Response, error)
-	Get(ipReservationID string) (*IPReservation, *Response, error)
-	Remove(ipReservationID string) (*Response, error)
-}
-
-// IPReservationServiceOp implements the IPReservationService interface
-type IPReservationServiceOp struct {
-	client *Client
-}
-
-// IPReservationRequest represents the body of a reservation request
-type IPReservationRequest struct {
-	Type     string `json:"type"`
-	Quantity int    `json:"quantity"`
-	Comments string `json:"comments"`
-	Facility string `json:"facility"`
-}
-
-// IPReservation represent an IP reservation for a single project
-type IPReservation struct {
-	ID            string              `json:"id"`
-	Network       string              `json:"network"`
-	Address       string              `json:"address"`
-	AddressFamily int                 `json:"address_family"`
-	Netmask       string              `json:"netmask"`
-	Public        bool                `json:"public"`
-	Cidr          int                 `json:"cidr"`
-	Management    bool                `json:"management"`
-	Manageable    bool                `json:"manageable"`
-	Addon         bool                `json:"addon"`
-	Bill          bool                `json:"bill"`
-	Assignments   []map[string]string `json:"assignments"`
-	Created       string              `json:"created_at,omitempty"`
-	Updated       string              `json:"updated_at,omitempty"`
-	Href          string              `json:"href"`
-	Facility      Facility            `json:"facility,omitempty"`
+	return ipa, resp, err
 }
 
 type ipReservationRoot struct {
-	IPReservations []IPReservation `json:"ip_addresses"`
+	Reservations []IPAddressReservation `json:"ip_addresses"`
 }
 
-// List provides a list of IP resevations for a single project.
-func (i *IPReservationServiceOp) List(projectID string) ([]IPReservation, *Response, error) {
+// ListReservations provides a list of IP resevations for a single project.
+func (i *IPServiceOp) ListReservations(projectID string) ([]IPAddressReservation, *Response, error) {
 	path := fmt.Sprintf("%s/%s%s", projectBasePath, projectID, ipBasePath)
 
 	req, err := i.client.NewRequest("GET", path, nil)
@@ -150,47 +133,36 @@ func (i *IPReservationServiceOp) List(projectID string) ([]IPReservation, *Respo
 	if err != nil {
 		return nil, resp, err
 	}
-	return reservations.IPReservations, resp, err
+	return reservations.Reservations, resp, nil
 }
 
-// RequestMore requests more IP space for a project in order to have additional IP addresses to assign to devices
-func (i *IPReservationServiceOp) RequestMore(projectID string, ipReservationReq *IPReservationRequest) (*IPReservation, *Response, error) {
-	path := fmt.Sprintf("%s/%s%s", projectBasePath, projectID, ipBasePath)
-
-	req, err := i.client.NewRequest("POST", path, &ipReservationReq)
+// GetReservationByCIDR returns reservation by CIDR IPv4 net/mask expression, e.g "147.229.20.148/30".
+// This is useful upon submitting a reservation request, which returns CIDR of allocated block in exactly this format.
+func (i *IPServiceOp) GetReservationByCIDR(projectID, cidrString string) (*IPAddressReservation, *Response, error) {
+	cidrSlice := strings.Split(cidrString, "/")
+	if len(cidrSlice) != 2 {
+		return nil, nil, fmt.Errorf("Invalid CIDR expression: %s", cidrString)
+	}
+	network := cidrSlice[0]
+	cidr, err := strconv.Atoi(cidrSlice[1])
 	if err != nil {
 		return nil, nil, err
 	}
-
-	ip := new(IPReservation)
-	resp, err := i.client.Do(req, ip)
+	rs, resp, err := i.ListReservations(projectID)
 	if err != nil {
 		return nil, resp, err
 	}
-	return ip, resp, err
+	for _, r := range rs {
+		if r.Network == network && r.Cidr == cidr {
+			return &r, resp, nil
+		}
+	}
+	return nil, resp, fmt.Errorf("Couldn't find reservation for CIDR %s", cidrString)
+
 }
 
-// Get returns a single IP reservation object
-func (i *IPReservationServiceOp) Get(ipReservationID string) (*IPReservation, *Response, error) {
-	path := fmt.Sprintf("%s/%s", ipBasePath, ipReservationID)
-
-	req, err := i.client.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	reservation := new(IPReservation)
-	resp, err := i.client.Do(req, reservation)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return reservation, resp, err
-}
-
-// Remove removes an IP reservation from the project.
-func (i *IPReservationServiceOp) Remove(ipReservationID string) (*Response, error) {
-	path := fmt.Sprintf("%s/%s", ipBasePath, ipReservationID)
+func (i *IPServiceOp) deleteFromIP(resourceID string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", ipBasePath, resourceID)
 
 	req, err := i.client.NewRequest("DELETE", path, nil)
 	if err != nil {
@@ -198,9 +170,75 @@ func (i *IPReservationServiceOp) Remove(ipReservationID string) (*Response, erro
 	}
 
 	resp, err := i.client.Do(req, nil)
+	return resp, err
+}
+
+// Unassign unassigns an IP address from the device to which it is currently assignmed.
+// This will remove the relationship between an IP and the device and will make the IP
+// address available to be assigned to another device.
+func (i *IPServiceOp) Unassign(assignmentID string) (*Response, error) {
+	return i.deleteFromIP(assignmentID)
+}
+
+// Assign assigns an IP address to a device. The IP address must be in one of the IP ranges assigned to the device’s project.
+func (i *IPServiceOp) Assign(deviceID string, assignRequest *AddressField) (*IPAddressAssignment, *Response, error) {
+	path := fmt.Sprintf("%s/%s%s", deviceBasePath, deviceID, ipBasePath)
+
+	req, err := i.client.NewRequest("POST", path, assignRequest)
+
+	ipa := new(IPAddressAssignment)
+	resp, err := i.client.Do(req, ipa)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
 
-	return resp, err
+	return ipa, resp, err
+}
+
+// IPReservationRequest represents the body of a reservation request
+type IPReservationRequest struct {
+	Type     string `json:"type"`
+	Quantity int    `json:"quantity"`
+	Comments string `json:"comments"`
+	Facility string `json:"facility"`
+}
+
+// RequestReservation requests more IP space for a project in order to have additional IP addresses to assign to devices
+func (i *IPServiceOp) RequestReservation(projectID string, ipReservationReq *IPReservationRequest) (*AddressField, *Response, error) {
+	path := fmt.Sprintf("%s/%s%s", projectBasePath, projectID, ipBasePath)
+
+	req, err := i.client.NewRequest("POST", path, &ipReservationReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ip := new(AddressField)
+	resp, err := i.client.Do(req, ip)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ip, resp, err
+}
+
+// RemoveReservation removes an IP reservation from the project.
+func (i *IPServiceOp) RemoveReservation(ipReservationID string) (*Response, error) {
+	return i.deleteFromIP(ipReservationID)
+}
+
+// GetAvailableAddresses lists addresses available from a reserved block
+func (i *IPServiceOp) GetAvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error) {
+	path := fmt.Sprintf("%s/%s/available", ipBasePath, ipReservationID)
+
+	req, err := i.client.NewRequest("GET", path, r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ar := new(AvailableResponse)
+	resp, err := i.client.Do(req, ar)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ar.Available, resp, nil
+
 }

--- a/ip.go
+++ b/ip.go
@@ -29,7 +29,7 @@ type ipAddressCommon struct {
 	AddressFamily int    `json:"address_family"`
 	Netmask       string `json:"netmask"`
 	Public        bool   `json:"public"`
-	Cidr          int    `json:"cidr"`
+	CIDR          int    `json:"cidr"`
 	Created       string `json:"created_at,omitempty"`
 	Updated       string `json:"updated_at,omitempty"`
 	Href          string `json:"href"`
@@ -52,7 +52,7 @@ type AvailableResponse struct {
 
 // AvailableRequest is a type for listing available addresses from a reserved block.
 type AvailableRequest struct {
-	Cidr int `json:"cidr"`
+	CIDR int `json:"cidr"`
 }
 
 // IPAddressAssignment is created when an IP address from reservation block is assigned to a device.
@@ -153,7 +153,7 @@ func (i *IPServiceOp) GetReservationByCIDR(projectID, cidrString string) (*IPAdd
 		return nil, resp, err
 	}
 	for _, r := range rs {
-		if r.Network == network && r.Cidr == cidr {
+		if r.Network == network && r.CIDR == cidr {
 			return &r, resp, nil
 		}
 	}

--- a/ip_test.go
+++ b/ip_test.go
@@ -1,0 +1,78 @@
+package packngo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIPReservation(t *testing.T) {
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+	quantityToMask := map[int]string{
+		1: "32", 2: "31", 4: "30", 8: "29", 16: "28",
+	}
+
+	testFac := "ewr1"
+	quantity := 2
+
+	req := IPReservationRequest{
+		Type:     "public_ipv4",
+		Quantity: quantity,
+		Comments: "packngo test",
+		Facility: testFac,
+	}
+
+	af, _, err := c.Ips.RequestReservation(projectID, &req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addrMask := strings.Split(af.Address, "/")
+	if addrMask[1] != quantityToMask[quantity] {
+		t.Errorf(
+			"CIDR prefix length for requested reservation should be %s, was %s",
+			quantityToMask[quantity], addrMask[1])
+	}
+
+	res, _, err := c.Ips.GetReservationByCIDR(projectID, af.Address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Facility.Code != testFac {
+		t.Errorf(
+			"Facility of new reservation should be %s, was %s", testFac,
+			res.Facility.Code)
+	}
+
+	ipList, _, err := c.Ips.ListReservations(projectID)
+	if len(ipList) != 1 {
+		t.Errorf("There should be only one reservation, was: %s", ipList)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sameRes, _, err := c.Ips.GetReservation(res.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sameRes.ID != res.ID {
+		t.Errorf("re-requested test reservation should be %s, is %s",
+			res, sameRes)
+	}
+
+	availableAddresses, _, err := c.Ips.GetAvailableAddresses(
+		res.ID, &AvailableRequest{Cidr: 32})
+	if len(availableAddresses) != quantity {
+		t.Errorf("New block should have %d available addresses, got %s",
+			quantity, availableAddresses)
+	}
+
+	_, err = c.Ips.RemoveReservation(res.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = c.Ips.GetReservation(res.ID)
+	if err == nil {
+		t.Errorf("Reservation %s should be deleted at this point", res)
+	}
+}

--- a/ip_test.go
+++ b/ip_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 )
 
-func TestIPReservation(t *testing.T) {
+func TestAccIPReservation(t *testing.T) {
+	if !doAcceptanceTests() {
+		return
+	}
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 	quantityToMask := map[int]string{

--- a/ip_test.go
+++ b/ip_test.go
@@ -64,6 +64,9 @@ func TestAccIPReservation(t *testing.T) {
 
 	availableAddresses, _, err := c.ProjectIPs.AvailableAddresses(
 		res.ID, &AvailableRequest{CIDR: 32})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(availableAddresses) != quantity {
 		t.Errorf("New block should have %d available addresses, got %s",
 			quantity, availableAddresses)

--- a/ip_test.go
+++ b/ip_test.go
@@ -22,7 +22,7 @@ func TestIPReservation(t *testing.T) {
 		Facility: testFac,
 	}
 
-	af, _, err := c.Ips.RequestReservation(projectID, &req)
+	af, _, err := c.IPs.RequestReservation(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestIPReservation(t *testing.T) {
 			quantityToMask[quantity], addrMask[1])
 	}
 
-	res, _, err := c.Ips.GetReservationByCIDR(projectID, af.Address)
+	res, _, err := c.IPs.GetReservationByCIDR(projectID, af.Address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestIPReservation(t *testing.T) {
 			res.Facility.Code)
 	}
 
-	ipList, _, err := c.Ips.ListReservations(projectID)
+	ipList, _, err := c.IPs.ListReservations(projectID)
 	if len(ipList) != 1 {
 		t.Errorf("There should be only one reservation, was: %s", ipList)
 	}
@@ -51,7 +51,7 @@ func TestIPReservation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sameRes, _, err := c.Ips.GetReservation(res.ID)
+	sameRes, _, err := c.IPs.GetReservation(res.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,18 +60,18 @@ func TestIPReservation(t *testing.T) {
 			res, sameRes)
 	}
 
-	availableAddresses, _, err := c.Ips.GetAvailableAddresses(
-		res.ID, &AvailableRequest{Cidr: 32})
+	availableAddresses, _, err := c.IPs.GetAvailableAddresses(
+		res.ID, &AvailableRequest{CIDR: 32})
 	if len(availableAddresses) != quantity {
 		t.Errorf("New block should have %d available addresses, got %s",
 			quantity, availableAddresses)
 	}
 
-	_, err = c.Ips.RemoveReservation(res.ID)
+	_, err = c.IPs.RemoveReservation(res.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = c.Ips.GetReservation(res.ID)
+	_, _, err = c.IPs.GetReservation(res.ID)
 	if err == nil {
 		t.Errorf("Reservation %s should be deleted at this point", res)
 	}

--- a/ip_test.go
+++ b/ip_test.go
@@ -17,6 +17,14 @@ func TestAccIPReservation(t *testing.T) {
 	testFac := "ewr1"
 	quantity := 2
 
+	ipList, _, err := c.ProjectIPs.List(projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ipList) != 0 {
+		t.Fatalf("There should be no reservations a new project, existing list: %s", ipList)
+	}
+
 	req := IPReservationRequest{
 		Type:     "public_ipv4",
 		Quantity: quantity,
@@ -30,7 +38,7 @@ func TestAccIPReservation(t *testing.T) {
 	}
 	addrMask := strings.Split(af.Address, "/")
 	if addrMask[1] != quantityToMask[quantity] {
-		t.Errorf(
+		t.Fatalf(
 			"CIDR prefix length for requested reservation should be %s, was %s",
 			quantityToMask[quantity], addrMask[1])
 	}
@@ -40,14 +48,14 @@ func TestAccIPReservation(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res.Facility.Code != testFac {
-		t.Errorf(
+		t.Fatalf(
 			"Facility of new reservation should be %s, was %s", testFac,
 			res.Facility.Code)
 	}
 
-	ipList, _, err := c.ProjectIPs.List(projectID)
+	ipList, _, err = c.ProjectIPs.List(projectID)
 	if len(ipList) != 1 {
-		t.Errorf("There should be only one reservation, was: %s", ipList)
+		t.Fatalf("There should be only one reservation, was: %s", ipList)
 	}
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +66,7 @@ func TestAccIPReservation(t *testing.T) {
 		t.Fatal(err)
 	}
 	if sameRes.ID != res.ID {
-		t.Errorf("re-requested test reservation should be %s, is %s",
+		t.Fatalf("re-requested test reservation should be %s, is %s",
 			res, sameRes)
 	}
 
@@ -68,7 +76,7 @@ func TestAccIPReservation(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(availableAddresses) != quantity {
-		t.Errorf("New block should have %d available addresses, got %s",
+		t.Fatalf("New block should have %d available addresses, got %s",
 			quantity, availableAddresses)
 	}
 
@@ -78,6 +86,6 @@ func TestAccIPReservation(t *testing.T) {
 	}
 	_, _, err = c.ProjectIPs.Get(res.ID)
 	if err == nil {
-		t.Errorf("Reservation %s should be deleted at this point", res)
+		t.Fatalf("Reservation %s should be deleted at this point", res)
 	}
 }

--- a/ip_test.go
+++ b/ip_test.go
@@ -22,7 +22,7 @@ func TestIPReservation(t *testing.T) {
 		Facility: testFac,
 	}
 
-	af, _, err := c.IPs.RequestReservation(projectID, &req)
+	af, _, err := c.ProjectIPs.Request(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestIPReservation(t *testing.T) {
 			quantityToMask[quantity], addrMask[1])
 	}
 
-	res, _, err := c.IPs.GetReservationByCIDR(projectID, af.Address)
+	res, _, err := c.ProjectIPs.GetByCIDR(projectID, af.Address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestIPReservation(t *testing.T) {
 			res.Facility.Code)
 	}
 
-	ipList, _, err := c.IPs.ListReservations(projectID)
+	ipList, _, err := c.ProjectIPs.List(projectID)
 	if len(ipList) != 1 {
 		t.Errorf("There should be only one reservation, was: %s", ipList)
 	}
@@ -51,7 +51,7 @@ func TestIPReservation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sameRes, _, err := c.IPs.GetReservation(res.ID)
+	sameRes, _, err := c.ProjectIPs.Get(res.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,18 +60,18 @@ func TestIPReservation(t *testing.T) {
 			res, sameRes)
 	}
 
-	availableAddresses, _, err := c.IPs.GetAvailableAddresses(
+	availableAddresses, _, err := c.ProjectIPs.AvailableAddresses(
 		res.ID, &AvailableRequest{CIDR: 32})
 	if len(availableAddresses) != quantity {
 		t.Errorf("New block should have %d available addresses, got %s",
 			quantity, availableAddresses)
 	}
 
-	_, err = c.IPs.RemoveReservation(res.ID)
+	_, err = c.ProjectIPs.Remove(res.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = c.IPs.GetReservation(res.ID)
+	_, _, err = c.ProjectIPs.Get(res.ID)
 	if err == nil {
 		t.Errorf("Reservation %s should be deleted at this point", res)
 	}

--- a/ip_test.go
+++ b/ip_test.go
@@ -6,9 +6,8 @@ import (
 )
 
 func TestAccIPReservation(t *testing.T) {
-	if !doAcceptanceTests() {
-		return
-	}
+	skipUnlessAcceptanceTestsAllowed(t)
+
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 	quantityToMask := map[int]string{

--- a/packngo.go
+++ b/packngo.go
@@ -94,7 +94,8 @@ type Client struct {
 	Projects         ProjectService
 	Facilities       FacilityService
 	OperatingSystems OSService
-	IPs              IPService
+	DeviceIPs        DeviceIPService
+	ProjectIPs       ProjectIPService
 	Volumes          VolumeService
 }
 
@@ -200,7 +201,8 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.Projects = &ProjectServiceOp{client: c}
 	c.Facilities = &FacilityServiceOp{client: c}
 	c.OperatingSystems = &OSServiceOp{client: c}
-	c.IPs = &IPServiceOp{client: c}
+	c.DeviceIPs = &DeviceIPServiceOp{client: c}
+	c.ProjectIPs = &ProjectIPServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}
 
 	return c, nil

--- a/packngo.go
+++ b/packngo.go
@@ -42,6 +42,11 @@ type Response struct {
 	Rate
 }
 
+// Href is an API link
+type Href struct {
+	Href string `json:"href"`
+}
+
 func (r *Response) populateRate() {
 	// parse the rate limit headers and populate Response.Rate
 	if limit := r.Header.Get(headerRateLimit); limit != "" {
@@ -90,7 +95,6 @@ type Client struct {
 	Facilities       FacilityService
 	OperatingSystems OSService
 	Ips              IPService
-	IpReservations   IPReservationService
 	Volumes          VolumeService
 }
 
@@ -171,6 +175,9 @@ func NewClient(consumerToken string, apiKey string, httpClient *http.Client) *Cl
 	client, _ := NewClientWithBaseURL(consumerToken, apiKey, httpClient, baseURL)
 	return client
 }
+
+// NewClientWithBaseURL returns a Client pointing to nonstandard API URL, e.g.
+// for mocking the remote API
 func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.Client, apiBaseURL string) (*Client, error) {
 	if httpClient == nil {
 		// Don't fall back on http.DefaultClient as it's not nice to adjust state
@@ -194,7 +201,6 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.Facilities = &FacilityServiceOp{client: c}
 	c.OperatingSystems = &OSServiceOp{client: c}
 	c.Ips = &IPServiceOp{client: c}
-	c.IpReservations = &IPReservationServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}
 
 	return c, nil

--- a/packngo.go
+++ b/packngo.go
@@ -94,7 +94,7 @@ type Client struct {
 	Projects         ProjectService
 	Facilities       FacilityService
 	OperatingSystems OSService
-	Ips              IPService
+	IPs              IPService
 	Volumes          VolumeService
 }
 
@@ -200,7 +200,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.Projects = &ProjectServiceOp{client: c}
 	c.Facilities = &FacilityServiceOp{client: c}
 	c.OperatingSystems = &OSServiceOp{client: c}
-	c.Ips = &IPServiceOp{client: c}
+	c.IPs = &IPServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}
 
 	return c, nil

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -1,0 +1,74 @@
+package packngo
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
+	testInfoMsg       = `
+packngo tests create and destroy resources in the Packet Host.
+They will likely cost you some credit. If you really want to run
+the tests, please export PACKNGO_TEST env var to nonempty string.`
+	testProjectPrefix = "TEST_DELME_2d768716_"
+)
+
+func randString8() string {
+	n := 8
+	rand.Seed(time.Now().UnixNano())
+	letterRunes := []rune("acdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func setupWithProject(t *testing.T) (*Client, string, func()) {
+	c := setup(t)
+	p, _, err := c.Projects.Create(&ProjectCreateRequest{Name: testProjectPrefix + randString8()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c, p.ID, func() {
+		_, err := c.Projects.Delete(p.ID)
+		if err != nil {
+			panic(fmt.Errorf("while deleting %s: %s", p, err))
+		}
+	}
+
+}
+
+func setup(t *testing.T) *Client {
+	if os.Getenv("PACKNGO_TEST") == "" {
+		t.Fatal(testInfoMsg)
+	}
+	apiToken := os.Getenv(packetTokenEnvVar)
+	if apiToken == "" {
+		t.Fatalf("If you want to run packngo test, you must export %s.", packetTokenEnvVar)
+	}
+	c := NewClient("packngo test", apiToken, nil)
+	return c
+}
+
+func projectTeardown(c *Client) {
+	ps, _, err := c.Projects.List()
+	if err != nil {
+		panic(fmt.Errorf("while teardown: %s", err))
+	}
+	for _, p := range ps {
+		if strings.HasPrefix(p.Name, testProjectPrefix) {
+			_, err := c.Projects.Delete(p.ID)
+			if err != nil {
+				panic(fmt.Errorf("while deleting %s: %s", p, err))
+			}
+		}
+	}
+
+}

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -11,11 +11,7 @@ import (
 
 const (
 	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
-	packngoTestVar    = "PACKNGO_TEST_ACTUAL_API"
-	testInfoMsg       = `
-packngo tests create and destroy resources in the Packet Host.
-They will likely cost you some credit. If you really want to run
-the tests, please export %s env var to nonempty string.`
+	packngoAccTestVar = "PACKNGO_TEST_ACTUAL_API"
 	testProjectPrefix = "PACKNGO_TEST_DELME_2d768716_"
 )
 
@@ -46,10 +42,11 @@ func setupWithProject(t *testing.T) (*Client, string, func()) {
 
 }
 
+func doAcceptanceTests() bool {
+	return os.Getenv(packngoAccTestVar) != ""
+}
+
 func setup(t *testing.T) *Client {
-	if os.Getenv(packngoTestVar) == "" {
-		t.Fatalf(testInfoMsg, packngoTestVar)
-	}
 	apiToken := os.Getenv(packetTokenEnvVar)
 	if apiToken == "" {
 		t.Fatalf("If you want to run packngo test, you must export %s.", packetTokenEnvVar)

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -42,8 +42,10 @@ func setupWithProject(t *testing.T) (*Client, string, func()) {
 
 }
 
-func doAcceptanceTests() bool {
-	return os.Getenv(packngoAccTestVar) != ""
+func skipUnlessAcceptanceTestsAllowed(t *testing.T) {
+	if os.Getenv(packngoAccTestVar) == "" {
+		t.Skipf("%s is not set", packngoAccTestVar)
+	}
 }
 
 func setup(t *testing.T) *Client {

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -11,11 +11,12 @@ import (
 
 const (
 	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
+	packngoTestVar    = "PACKNGO_TEST_ACTUAL_API"
 	testInfoMsg       = `
 packngo tests create and destroy resources in the Packet Host.
 They will likely cost you some credit. If you really want to run
-the tests, please export PACKNGO_TEST env var to nonempty string.`
-	testProjectPrefix = "TEST_DELME_2d768716_"
+the tests, please export %s env var to nonempty string.`
+	testProjectPrefix = "PACKNGO_TEST_DELME_2d768716_"
 )
 
 func randString8() string {
@@ -46,8 +47,8 @@ func setupWithProject(t *testing.T) (*Client, string, func()) {
 }
 
 func setup(t *testing.T) *Client {
-	if os.Getenv("PACKNGO_TEST") == "" {
-		t.Fatal(testInfoMsg)
+	if os.Getenv(packngoTestVar) == "" {
+		t.Fatalf(testInfoMsg, packngoTestVar)
 	}
 	apiToken := os.Getenv(packetTokenEnvVar)
 	if apiToken == "" {

--- a/projects.go
+++ b/projects.go
@@ -11,12 +11,7 @@ type ProjectService interface {
 	Create(*ProjectCreateRequest) (*Project, *Response, error)
 	Update(*ProjectUpdateRequest) (*Project, *Response, error)
 	Delete(string) (*Response, error)
-	ListIPAddresses(string) ([]IPAddress, *Response, error)
 	ListVolumes(string) ([]Volume, *Response, error)
-}
-
-type ipsRoot struct {
-	IPAddresses []IPAddress `json:"ip_addresses"`
 }
 
 type volumesRoot struct {
@@ -67,22 +62,6 @@ func (p ProjectUpdateRequest) String() string {
 // ProjectServiceOp implements ProjectService
 type ProjectServiceOp struct {
 	client *Client
-}
-
-func (s *ProjectServiceOp) ListIPAddresses(projectID string) ([]IPAddress, *Response, error) {
-	url := fmt.Sprintf("%s/%s/ips", projectBasePath, projectID)
-	req, err := s.client.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	root := new(ipsRoot)
-	resp, err := s.client.Do(req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return root.IPAddresses, resp, err
 }
 
 // List returns the user's projects

--- a/projects_test.go
+++ b/projects_test.go
@@ -2,7 +2,11 @@ package packngo
 
 import "testing"
 
-func TestProject(t *testing.T) {
+func TestAccProject(t *testing.T) {
+	if !doAcceptanceTests() {
+		return
+	}
+
 	c := setup(t)
 	defer projectTeardown(c)
 

--- a/projects_test.go
+++ b/projects_test.go
@@ -12,30 +12,30 @@ func TestAccProject(t *testing.T) {
 	pcr := ProjectCreateRequest{Name: rs}
 	p, _, err := c.Projects.Create(&pcr)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if p.Name != rs {
-		t.Errorf("Expected new project name to be %s, not %s", rs, p.Name)
+		t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
 	}
 	rs = testProjectPrefix + randString8()
 	pur := ProjectUpdateRequest{ID: p.ID, Name: rs}
 	p, _, err = c.Projects.Update(&pur)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if p.Name != rs {
-		t.Errorf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
+		t.Fatalf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
 	}
 	gotProject, _, err := c.Projects.Get(p.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if gotProject.Name != rs {
-		t.Errorf("Expected the name of the GOT project to be %s, not %s", rs, gotProject.Name)
+		t.Fatalf("Expected the name of the GOT project to be %s, not %s", rs, gotProject.Name)
 	}
 	_, err = c.Projects.Delete(p.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 }

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,0 +1,39 @@
+package packngo
+
+import "testing"
+
+func TestProject(t *testing.T) {
+	c := setup(t)
+	defer projectTeardown(c)
+
+	rs := testProjectPrefix + randString8()
+	pcr := ProjectCreateRequest{Name: rs}
+	p, _, err := c.Projects.Create(&pcr)
+	if err != nil {
+		t.Error(err)
+	}
+	if p.Name != rs {
+		t.Errorf("Expected new project name to be %s, not %s", rs, p.Name)
+	}
+	rs = testProjectPrefix + randString8()
+	pur := ProjectUpdateRequest{ID: p.ID, Name: rs}
+	p, _, err = c.Projects.Update(&pur)
+	if err != nil {
+		t.Error(err)
+	}
+	if p.Name != rs {
+		t.Errorf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
+	}
+	gotProject, _, err := c.Projects.Get(p.ID)
+	if err != nil {
+		t.Error(err)
+	}
+	if gotProject.Name != rs {
+		t.Errorf("Expected the name of the GOT project to be %s, not %s", rs, gotProject.Name)
+	}
+	_, err = c.Projects.Delete(p.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+}

--- a/projects_test.go
+++ b/projects_test.go
@@ -3,9 +3,7 @@ package packngo
 import "testing"
 
 func TestAccProject(t *testing.T) {
-	if !doAcceptanceTests() {
-		return
-	}
+	skipUnlessAcceptanceTestsAllowed(t)
 
 	c := setup(t)
 	defer projectTeardown(c)


### PR DESCRIPTION
hi, I refactored the IP service a bit so that it captures the current state of the API.

I identify 2 resources under the /ips/ method:
1) Reservations, which are created by the POST to `/projects/{id}/ips`. It's actually a CIDR block of addresses. 
2) Assignments, which are created by POST to `/devices/{id}/ips`. Those represent coupling between address from a block, and a device.

I noticed that:
- GET to `projects/{id}/ips` will list only reservations, not assignments (but assigmnents are linked from reservations).
- fields which are only in Reservation: facility, available, assignments, addon, bill
- fields which are only in Assignment: assigned_to.

I tried to express that in the golang types without duplication, and then rewrote the API functions with the new types.

I removed the IP listing function from projects.go, as it's already in ip.go. 

I wrote tests for projects.go, and for ip.go. 

This might break some code from https://godoc.org/github.com/packethost/packngo?importers, but I think it's not big deal - most of that is Terraform (which uses govendor, so should be safe), and the other projects use mostly the Devices service, not the IPs.

Please take a look and let me know what do you think.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/32)
<!-- Reviewable:end -->
