### PR TITLE
Add management and manageable flags to the IP address struct

### DIFF
--- a/devices_test.go
+++ b/devices_test.go
@@ -160,6 +160,10 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !assignment.Management {
+		t.Fatal("Management flag for assignment resource must be True")
+	}
+
 	d, _, err = c.Devices.Get(d.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/devices_test.go
+++ b/devices_test.go
@@ -21,6 +21,13 @@ func waitDeviceActive(id string, c *Client) (*Device, error) {
 	return nil, fmt.Errorf("device %s is still not active after timeout", id)
 }
 
+func deleteDevice(t *testing.T, c *Client, id string) {
+	_, err := c.Devices.Delete(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAccDeviceBasic(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	t.Parallel()
@@ -43,6 +50,8 @@ func TestAccDeviceBasic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer deleteDevice(t, c, d.ID)
+
 	dID := d.ID
 
 	d, err = waitDeviceActive(dID, c)
@@ -65,10 +74,10 @@ func TestAccDeviceBasic(t *testing.T) {
 	if newD.Hostname != newHN {
 		t.Fatalf("hostname of test device should be %s, but is %s", newHN, newD.Hostname)
 	}
-
-	_, err = c.Devices.Delete(dID)
-	if err != nil {
-		t.Fatal(err)
+	for _, ipa := range newD.Network {
+		if !ipa.Management {
+			t.Fatalf("management flag for all the IP addresses in a new device should be True: was %s", ipa)
+		}
 	}
 }
 
@@ -97,6 +106,8 @@ func TestAccDevicePXE(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	defer deleteDevice(t, c, d.ID)
+
 	d, err = waitDeviceActive(d.ID, c)
 	if err != nil {
 		t.Fatal(err)
@@ -107,10 +118,6 @@ func TestAccDevicePXE(t *testing.T) {
 	}
 	if d.IPXEScriptURL != pxeURL {
 		t.Fatalf("ipxe_script_url should be %s", pxeURL)
-	}
-	_, err = c.Devices.Delete(d.ID)
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -137,6 +144,7 @@ func TestAccDeviceAssignIP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer deleteDevice(t, c, d.ID)
 
 	d, err = waitDeviceActive(d.ID, c)
 	if err != nil {
@@ -160,8 +168,8 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !assignment.Management {
-		t.Fatal("Management flag for assignment resource must be True")
+	if assignment.Management {
+		t.Error("Management flag for assignment resource must be False")
 	}
 
 	d, _, err = c.Devices.Get(d.ID)
@@ -229,10 +237,4 @@ func TestAccDeviceAssignIP(t *testing.T) {
 				assignment, d)
 		}
 	}
-
-	_, err = c.Devices.Delete(d.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 }

--- a/ip.go
+++ b/ip.go
@@ -37,6 +37,8 @@ type ipAddressCommon struct {
 	Created       string `json:"created_at,omitempty"`
 	Updated       string `json:"updated_at,omitempty"`
 	Href          string `json:"href"`
+	Management    bool   `json:"management"`
+	Manageable    bool   `json:"manageable"`
 }
 
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).

--- a/ip_test.go
+++ b/ip_test.go
@@ -47,6 +47,10 @@ func TestAccIPReservation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if res.Management {
+		t.Fatal("Management flag of new reservation block must be False")
+	}
 	if res.Facility.Code != testFac {
 		t.Fatalf(
 			"Facility of new reservation should be %s, was %s", testFac,


### PR DESCRIPTION
This PR adds the 2 flags to the IP address struct, so that it's possible to distinguish between defautl and floating IPs.

Necessary for https://github.com/terraform-providers/terraform-provider-packet/pull/18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/40)
<!-- Reviewable:end -->
