### PR TITLE
Improve processing of errors from HTTP responses from the Packet API

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -64,13 +64,14 @@ func (r *Response) populateRate() {
 
 // ErrorResponse is the http response used on errrors
 type ErrorResponse struct {
-	Response *http.Response
-	Errors   []string `json:"errors"`
+	Response    *http.Response
+	Errors      []string `json:"errors"`
+	SingleError string   `json:"error"`
 }
 
 func (r *ErrorResponse) Error() string {
-	return fmt.Sprintf("%v %v: %d %v",
-		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, strings.Join(r.Errors, ", "))
+	return fmt.Sprintf("%v %v: %d %v %v",
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, strings.Join(r.Errors, ", "), r.SingleError)
 }
 
 // Client is the base API Client

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -69,6 +70,23 @@ func projectTeardown(c *Client) {
 				panic(fmt.Errorf("while deleting %s: %s", p, err))
 			}
 		}
+	}
+}
+
+func TestAccInvalidCredentials(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	c := NewClient("packngo test", "wrongApiToken", nil)
+	_, r, expectedErr := c.Projects.List()
+	matched, err := regexp.MatchString(".*Invalid.*", expectedErr.Error())
+	if err != nil {
+		t.Fatalf("Err while matching err string from response err %s: %s", expectedErr, err)
+	}
+	if r.StatusCode != 401 {
+		t.Fatalf("Expected 401 as response code, got: %d", r.StatusCode)
+	}
+
+	if !matched {
+		t.Fatalf("Unexpected error string: %s", expectedErr)
 	}
 
 }


### PR DESCRIPTION
Errors from the Packet API are returned in a single-key dictionary in the body of a HTTP Response.

Sometimes the dict is like:
```
{errors: ["device is in provisioning state"]}
```

but sometimes the dict is like
```
{error: "Invalid credentials"}
```

This PR makes packngo capture the second case, and adds a test.

This will enventually fix https://github.com/terraform-providers/terraform-provider-packet/issues/24.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/42)
<!-- Reviewable:end -->
