### PR TITLE
reflect API change when reserving IP for a project

### DIFF
--- a/devices_test.go
+++ b/devices_test.go
@@ -163,12 +163,14 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		Facility: testFac,
 	}
 
-	af, _, err := c.ProjectIPs.Request(projectID, &req)
+	reservation, _, err := c.ProjectIPs.Request(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assignment, _, err := c.DeviceIPs.Assign(d.ID, af)
+	af := AddressStruct{Address: fmt.Sprintf("%s/%d", reservation.Address, reservation.CIDR)}
+
+	assignment, _, err := c.DeviceIPs.Assign(d.ID, &af)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,10 +184,10 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// If the quantity in the IPReservationRequest is >1, this test won't work.
+	// If the Quantity in the IPReservationRequest is >1, this test won't work.
 	// The assignment CIDR would then have to be extracted from the reserved
 	// block.
-	reservation, _, err := c.ProjectIPs.GetByCIDR(projectID, af.Address)
+	reservation, _, err = c.ProjectIPs.Get(reservation.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ip_test.go
+++ b/ip_test.go
@@ -2,7 +2,6 @@ package packngo
 
 import (
 	"path"
-	"strings"
 	"testing"
 )
 
@@ -11,8 +10,8 @@ func TestAccIPReservation(t *testing.T) {
 
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
-	quantityToMask := map[int]string{
-		1: "32", 2: "31", 4: "30", 8: "29", 16: "28",
+	quantityToMask := map[int]int{
+		1: 32, 2: 31, 4: 30, 8: 29, 16: 28,
 	}
 
 	testFac := "ewr1"
@@ -33,20 +32,15 @@ func TestAccIPReservation(t *testing.T) {
 		Facility: testFac,
 	}
 
-	af, _, err := c.ProjectIPs.Request(projectID, &req)
+	res, _, err := c.ProjectIPs.Request(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
-	}
-	addrMask := strings.Split(af.Address, "/")
-	if addrMask[1] != quantityToMask[quantity] {
-		t.Fatalf(
-			"CIDR prefix length for requested reservation should be %s, was %s",
-			quantityToMask[quantity], addrMask[1])
 	}
 
-	res, _, err := c.ProjectIPs.GetByCIDR(projectID, af.Address)
-	if err != nil {
-		t.Fatal(err)
+	if res.CIDR != quantityToMask[quantity] {
+		t.Fatalf(
+			"CIDR prefix length for requested reservation should be %d, was %d",
+			quantityToMask[quantity], res.CIDR)
 	}
 
 	if path.Base(res.Project.Href) != projectID {


### PR DESCRIPTION
This PR reflects API change announced:

>  breaking API change is approaching next week; when requesting additional IP ranges using the `POST /projects/{id}/ips` method, the `address` property of the response object will no longer contain the CIDR range; we will be returning the full assignment object and the CIDR range can be read from the `cidr` property; please let us know if you need any additional time to adjust for this change to we can accommodate; our recommendation is to update any scripts to look for the `cidr` property if the `address` property does not end with `/[0-9]{2}$`;
> old:
>
> ```
> {
>   "address": "200.44.226.0/25"
> }
> ```
>
> new (example):
>
> ```{
>  "id": "036be0ae-9e01-4996-8ddb-6b5d9d34bfb5",
>  "cidr": 25,
>  "network": "240.154.87.0",
>  "address": "240.154.87.2",
>  "gateway": "240.154.87.1",
>  // snip
> }```

I removes the GetByCIDR method of the ProjectIPService, because it's not necessary anymore. Then the tests are adjusted.

Fixes #46

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/47)
<!-- Reviewable:end -->
