### PR TITLE
Improve DeviceUpdateRequest zero-value handling

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -95,12 +95,12 @@ type DeviceCreateRequest struct {
 
 // DeviceUpdateRequest type used to update a Packet device
 type DeviceUpdateRequest struct {
-	Hostname      string   `json:"hostname"`
+	Hostname      string   `json:"hostname,omitempty"`
 	Description   string   `json:"description"`
 	UserData      string   `json:"userdata"`
 	Locked        bool     `json:"locked"`
 	Tags          []string `json:"tags"`
-	AlwaysPXE     bool     `json:"always_pxe,omitempty"`
+	AlwaysPXE     bool     `json:"always_pxe"`
 	IPXEScriptURL string   `json:"ipxe_script_url,omitempty"`
 }
 

--- a/devices_test.go
+++ b/devices_test.go
@@ -154,7 +154,7 @@ func TestAccDevicePXE(t *testing.T) {
 		ProjectID:     projectID,
 		BillingCycle:  "hourly",
 		OS:            "custom_ipxe",
-		IPXEScriptURL: "https://boot.netboot.xyz",
+		IPXEScriptURL: pxeURL,
 		AlwaysPXE:     true,
 	}
 
@@ -170,11 +170,30 @@ func TestAccDevicePXE(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check that settings were persisted
 	if !d.AlwaysPXE {
-		t.Fatal("always_pxe should be set")
+		t.Fatal("always_pxe should be true")
 	}
 	if d.IPXEScriptURL != pxeURL {
-		t.Fatalf("ipxe_script_url should be %s", pxeURL)
+		t.Fatalf("ipxe_script_url should be \"%s\"", pxeURL)
+	}
+
+	// Check that we can update PXE options
+	pxeURL = "http://boot.netboot.xyz"
+	d, _, err = c.Devices.Update(d.ID,
+		&DeviceUpdateRequest{
+			AlwaysPXE:     false,
+			IPXEScriptURL: pxeURL,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.AlwaysPXE {
+		t.Fatalf("always_pxe should have been updated to false")
+	}
+	if d.IPXEScriptURL != pxeURL {
+		t.Fatalf("ipxe_script_url should have been updated to \"%s\"", pxeURL)
 	}
 }
 


### PR DESCRIPTION
- Fix a bug where updating AlwaysPXE to false would be omitted from the
  JSON request.
- An empty Hostname will not cause an error now, and the hostname will
  not be changed.

Also updated the PXE test so that it covers both of the above cases.

Fixes #65 
Fixes #66 
Helps https://github.com/terraform-providers/terraform-provider-packet/issues/56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/67)
<!-- Reviewable:end -->
