### PR TITLE
Make fields in update requests pointers

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -95,13 +95,13 @@ type DeviceCreateRequest struct {
 
 // DeviceUpdateRequest type used to update a Packet device
 type DeviceUpdateRequest struct {
-	Hostname      string   `json:"hostname,omitempty"`
-	Description   string   `json:"description"`
-	UserData      string   `json:"userdata"`
-	Locked        bool     `json:"locked"`
-	Tags          []string `json:"tags"`
-	AlwaysPXE     bool     `json:"always_pxe"`
-	IPXEScriptURL string   `json:"ipxe_script_url,omitempty"`
+	Hostname      *string   `json:"hostname,omitempty"`
+	Description   *string   `json:"description,omitempty"`
+	UserData      *string   `json:"userdata,omitempty"`
+	Locked        *bool     `json:"locked,omitempty"`
+	Tags          *[]string `json:"tags,omitempty"`
+	AlwaysPXE     *bool     `json:"always_pxe,omitempty"`
+	IPXEScriptURL *string   `json:"ipxe_script_url,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {

--- a/devices_test.go
+++ b/devices_test.go
@@ -68,7 +68,7 @@ func TestAccDeviceUpdate(t *testing.T) {
 		t.Fatal("root_password is empty or non-existent")
 	}
 	newHN := randString8()
-	ur := DeviceUpdateRequest{Hostname: newHN}
+	ur := DeviceUpdateRequest{Hostname: &newHN}
 
 	newD, _, err := c.Devices.Update(dID, &ur)
 	if err != nil {
@@ -180,10 +180,10 @@ func TestAccDevicePXE(t *testing.T) {
 
 	// Check that we can update PXE options
 	pxeURL = "http://boot.netboot.xyz"
+	bFalse := false
 	d, _, err = c.Devices.Update(d.ID,
 		&DeviceUpdateRequest{
-			AlwaysPXE:     false,
-			IPXEScriptURL: pxeURL,
+			AlwaysPXE: &bFalse,
 		},
 	)
 	if err != nil {
@@ -191,6 +191,14 @@ func TestAccDevicePXE(t *testing.T) {
 	}
 	if d.AlwaysPXE {
 		t.Fatalf("always_pxe should have been updated to false")
+	}
+	d, _, err = c.Devices.Update(d.ID,
+		&DeviceUpdateRequest{
+			IPXEScriptURL: &pxeURL,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if d.IPXEScriptURL != pxeURL {
 		t.Fatalf("ipxe_script_url should have been updated to \"%s\"", pxeURL)

--- a/organizations.go
+++ b/organizations.go
@@ -10,7 +10,7 @@ type OrganizationService interface {
 	List() ([]Organization, *Response, error)
 	Get(string) (*Organization, *Response, error)
 	Create(*OrganizationCreateRequest) (*Organization, *Response, error)
-	Update(*OrganizationUpdateRequest) (*Organization, *Response, error)
+	Update(string, *OrganizationUpdateRequest) (*Organization, *Response, error)
 	Delete(string) (*Response, error)
 	ListPaymentMethods(string) ([]PaymentMethod, *Response, error)
 }
@@ -60,12 +60,11 @@ func (o OrganizationCreateRequest) String() string {
 
 // OrganizationUpdateRequest type used to update a Packet organization
 type OrganizationUpdateRequest struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Website     string `json:"website"`
-	Twitter     string `json:"twitter"`
-	Logo        string `json:"logo"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Website     *string `json:"website,omitempty"`
+	Twitter     *string `json:"twitter,omitempty"`
+	Logo        *string `json:"logo,omitempty"`
 }
 
 func (o OrganizationUpdateRequest) String() string {
@@ -115,8 +114,8 @@ func (s *OrganizationServiceOp) Create(createRequest *OrganizationCreateRequest)
 }
 
 // Update updates an organization
-func (s *OrganizationServiceOp) Update(updateRequest *OrganizationUpdateRequest) (*Organization, *Response, error) {
-	path := fmt.Sprintf("%s/%s", organizationBasePath, updateRequest.ID)
+func (s *OrganizationServiceOp) Update(id string, updateRequest *OrganizationUpdateRequest) (*Organization, *Response, error) {
+	path := fmt.Sprintf("%s/%s", organizationBasePath, id)
 	organization := new(Organization)
 
 	resp, err := s.client.DoRequest("PATCH", path, updateRequest, organization)

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -23,14 +23,16 @@ func TestAccOrg(t *testing.T) {
 		t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
 	}
 	rs = testProjectPrefix + randString8()
+	oDesc := "Managed by Packngo."
+	oWeb := "http://quux.example.com"
+	oTwi := "bar"
 	pur := OrganizationUpdateRequest{
-		ID:          p.ID,
-		Name:        rs,
-		Description: "Managed by Packngo.",
-		Website:     "http://quux.example.com",
-		Twitter:     "bar",
+		Name:        &rs,
+		Description: &oDesc,
+		Website:     &oWeb,
+		Twitter:     &oTwi,
 	}
-	p, _, err = c.Organizations.Update(&pur)
+	p, _, err = c.Organizations.Update(p.ID, &pur)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/payment_methods.go
+++ b/payment_methods.go
@@ -8,7 +8,7 @@ type PaymentMethodService interface {
 	List() ([]PaymentMethod, *Response, error)
 	Get(string) (*PaymentMethod, *Response, error)
 	Create(*PaymentMethodCreateRequest) (*PaymentMethod, *Response, error)
-	Update(*PaymentMethodUpdateRequest) (*PaymentMethod, *Response, error)
+	Update(string, *PaymentMethodUpdateRequest) (*PaymentMethod, *Response, error)
 	Delete(string) (*Response, error)
 }
 
@@ -55,12 +55,11 @@ func (pm PaymentMethodCreateRequest) String() string {
 
 // PaymentMethodUpdateRequest type used to update a Packet payment method of an organization
 type PaymentMethodUpdateRequest struct {
-	ID             string `json:"id"`
-	Name           string `json:"name,omitempty"`
-	CardholderName string `json:"cardholder_name,omitempty"`
-	ExpMonth       string `json:"expiration_month,omitempty"`
-	ExpYear        string `json:"expiration_year,omitempty"`
-	BillingAddress string `json:"billing_address,omitempty"`
+	Name           *string `json:"name,omitempty"`
+	CardholderName *string `json:"cardholder_name,omitempty"`
+	ExpMonth       *string `json:"expiration_month,omitempty"`
+	ExpYear        *string `json:"expiration_year,omitempty"`
+	BillingAddress *string `json:"billing_address,omitempty"`
 }
 
 func (pm PaymentMethodUpdateRequest) String() string {

--- a/projects.go
+++ b/projects.go
@@ -9,7 +9,7 @@ type ProjectService interface {
 	List() ([]Project, *Response, error)
 	Get(string) (*Project, *Response, error)
 	Create(*ProjectCreateRequest) (*Project, *Response, error)
-	Update(*ProjectUpdateRequest) (*Project, *Response, error)
+	Update(string, *ProjectUpdateRequest) (*Project, *Response, error)
 	Delete(string) (*Response, error)
 }
 
@@ -47,9 +47,8 @@ func (p ProjectCreateRequest) String() string {
 
 // ProjectUpdateRequest type used to update a Packet project
 type ProjectUpdateRequest struct {
-	ID              string `json:"id"`
-	Name            string `json:"name,omitempty"`
-	PaymentMethodID string `json:"payment_method_id,omitempty"`
+	Name            *string `json:"name,omitempty"`
+	PaymentMethodID *string `json:"payment_method_id,omitempty"`
 }
 
 func (p ProjectUpdateRequest) String() string {
@@ -99,8 +98,8 @@ func (s *ProjectServiceOp) Create(createRequest *ProjectCreateRequest) (*Project
 }
 
 // Update updates a project
-func (s *ProjectServiceOp) Update(updateRequest *ProjectUpdateRequest) (*Project, *Response, error) {
-	path := fmt.Sprintf("%s/%s", projectBasePath, updateRequest.ID)
+func (s *ProjectServiceOp) Update(id string, updateRequest *ProjectUpdateRequest) (*Project, *Response, error) {
+	path := fmt.Sprintf("%s/%s", projectBasePath, id)
 	project := new(Project)
 
 	resp, err := s.client.DoRequest("PATCH", path, updateRequest, project)

--- a/projects_test.go
+++ b/projects_test.go
@@ -20,8 +20,8 @@ func TestAccProject(t *testing.T) {
 		t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
 	}
 	rs = testProjectPrefix + randString8()
-	pur := ProjectUpdateRequest{ID: p.ID, Name: rs}
-	p, _, err = c.Projects.Update(&pur)
+	pur := ProjectUpdateRequest{Name: &rs}
+	p, _, err = c.Projects.Update(p.ID, &pur)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sshkeys.go
+++ b/sshkeys.go
@@ -12,7 +12,7 @@ type SSHKeyService interface {
 	ProjectList(string) ([]SSHKey, *Response, error)
 	Get(string) (*SSHKey, *Response, error)
 	Create(*SSHKeyCreateRequest) (*SSHKey, *Response, error)
-	Update(*SSHKeyUpdateRequest) (*SSHKey, *Response, error)
+	Update(string, *SSHKeyUpdateRequest) (*SSHKey, *Response, error)
 	Delete(string) (*Response, error)
 }
 
@@ -49,9 +49,8 @@ func (s SSHKeyCreateRequest) String() string {
 
 // SSHKeyUpdateRequest type used to update an ssh key
 type SSHKeyUpdateRequest struct {
-	ID    string `json:"id"`
-	Label string `json:"label,omitempty"`
-	Key   string `json:"key,omitempty"`
+	Label *string `json:"label,omitempty"`
+	Key   *string `json:"key,omitempty"`
 }
 
 func (s SSHKeyUpdateRequest) String() string {
@@ -115,11 +114,11 @@ func (s *SSHKeyServiceOp) Create(createRequest *SSHKeyCreateRequest) (*SSHKey, *
 }
 
 // Update updates an ssh key
-func (s *SSHKeyServiceOp) Update(updateRequest *SSHKeyUpdateRequest) (*SSHKey, *Response, error) {
-	if updateRequest.Label == "" && updateRequest.Key == "" {
+func (s *SSHKeyServiceOp) Update(id string, updateRequest *SSHKeyUpdateRequest) (*SSHKey, *Response, error) {
+	if updateRequest.Label == nil && updateRequest.Key == nil {
 		return nil, nil, fmt.Errorf("You must set either Label or Key string for SSH Key update")
 	}
-	path := fmt.Sprintf("%s/%s", sshKeyBasePath, updateRequest.ID)
+	path := fmt.Sprintf("%s/%s", sshKeyBasePath, id)
 
 	sshKey := new(SSHKey)
 

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -136,10 +136,8 @@ func TestWrongSSHKeyUpdate(t *testing.T) {
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 	key := createKey(t, c, projectID)
-	req := SSHKeyUpdateRequest{
-		ID: key.ID,
-	}
-	_, _, err := c.SSHKeys.Update(&req)
+	req := SSHKeyUpdateRequest{}
+	_, _, err := c.SSHKeys.Update(key.ID, &req)
 	if err == nil {
 		t.Fatalf("SSHKey update by request without label or key string should be invalid")
 	}
@@ -154,10 +152,9 @@ func TestAccSSHKeyStringUpdate(t *testing.T) {
 
 	newKey := makePubKey(t)
 	req := SSHKeyUpdateRequest{
-		ID:  key.ID,
-		Key: newKey,
+		Key: &newKey,
 	}
-	got, _, err := c.SSHKeys.Update(&req)
+	got, _, err := c.SSHKeys.Update(key.ID, &req)
 	if err != nil {
 		t.Fatalf("failed to update key: %v", err)
 	}
@@ -178,11 +175,10 @@ func TestAccSSHKeyLabelUpdate(t *testing.T) {
 	defer teardown()
 	key := createKey(t, c, projectID)
 
-	req := SSHKeyUpdateRequest{
-		ID:    key.ID,
-		Label: key.Label + "-updated",
-	}
-	got, _, err := c.SSHKeys.Update(&req)
+	kLabel := key.Label + "-updated"
+
+	req := SSHKeyUpdateRequest{Label: &kLabel}
+	got, _, err := c.SSHKeys.Update(key.ID, &req)
 	if err != nil {
 		t.Fatalf("failed to update key: %v", err)
 	}
@@ -204,12 +200,12 @@ func TestAccSSHKeyUpdate(t *testing.T) {
 	key := createKey(t, c, projectID)
 
 	newKey := makePubKey(t)
+	kLabel := key.Label + "-updated"
 	req := SSHKeyUpdateRequest{
-		ID:    key.ID,
-		Key:   newKey,
-		Label: key.Label + "-updated",
+		Key:   &newKey,
+		Label: &kLabel,
 	}
-	got, _, err := c.SSHKeys.Update(&req)
+	got, _, err := c.SSHKeys.Update(key.ID, &req)
 	if err != nil {
 		t.Fatalf("failed to update key: %v", err)
 	}

--- a/volumes.go
+++ b/volumes.go
@@ -11,7 +11,7 @@ const (
 type VolumeService interface {
 	List(string, *ListOptions) ([]Volume, *Response, error)
 	Get(string) (*Volume, *Response, error)
-	Update(*VolumeUpdateRequest) (*Volume, *Response, error)
+	Update(string, *VolumeUpdateRequest) (*Volume, *Response, error)
 	Delete(string) (*Response, error)
 	Create(*VolumeCreateRequest, string) (*Volume, *Response, error)
 }
@@ -76,9 +76,8 @@ func (v VolumeCreateRequest) String() string {
 
 // VolumeUpdateRequest type used to update a Packet volume
 type VolumeUpdateRequest struct {
-	ID          string `json:"id"`
-	Description string `json:"description,omitempty"`
-	Plan        string `json:"plan,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Plan        *string `json:"plan,omitempty"`
 }
 
 // VolumeAttachment is a type from Packet API
@@ -150,8 +149,8 @@ func (v *VolumeServiceOp) Get(volumeID string) (*Volume, *Response, error) {
 }
 
 // Update updates a volume
-func (v *VolumeServiceOp) Update(updateRequest *VolumeUpdateRequest) (*Volume, *Response, error) {
-	path := fmt.Sprintf("%s/%s", volumeBasePath, updateRequest.ID)
+func (v *VolumeServiceOp) Update(id string, updateRequest *VolumeUpdateRequest) (*Volume, *Response, error) {
+	path := fmt.Sprintf("%s/%s", volumeBasePath, id)
 	volume := new(Volume)
 
 	resp, err := v.client.DoRequest("PATCH", path, updateRequest, volume)


### PR DESCRIPTION
Make fields in update requests pointers, so that they are properly omitted in the update request JSON when unset

Helps to fix https://github.com/terraform-providers/terraform-provider-packet/issues/56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/68)
<!-- Reviewable:end -->
