### PR TITLE
Fixed unit tests related to Fatalf.

### DIFF
--- a/ports_test.go
+++ b/ports_test.go
@@ -216,7 +216,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 	}
 
 	if nType != NetworkHybrid {
-		t.Fatalf("the device shoud be in network type L2 Bonded", plan)
+		t.Fatalf("the device should be in network type L2 Bonded")
 	}
 
 	if len(eth1.AttachedVirtualNetworks) != 0 {
@@ -366,7 +366,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 	}
 
 	if nType != NetworkL2Bonded {
-		t.Fatalf("the device shoud be in network type L2 Bonded", plan)
+		t.Fatalf("the device should be in network type L2 Bonded")
 	}
 
 	bond0, err := c.DevicePorts.GetBondPort(d.ID)

--- a/ports_test.go
+++ b/ports_test.go
@@ -216,7 +216,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 	}
 
 	if nType != NetworkHybrid {
-		t.Fatalf("the device should be in network type L2 Bonded")
+		t.Fatal("the device should now be in network type L2 Bonded")
 	}
 
 	if len(eth1.AttachedVirtualNetworks) != 0 {
@@ -270,7 +270,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 	}
 
 	if nType != NetworkL3 {
-		t.Fatalf("the %s device should be back in network type L3", plan)
+		t.Fatal("the device should now be back in network type L3")
 	}
 
 }
@@ -366,7 +366,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 	}
 
 	if nType != NetworkL2Bonded {
-		t.Fatalf("the device should be in network type L2 Bonded")
+		t.Fatal("the device should now be in network type L2 Bonded")
 	}
 
 	bond0, err := c.DevicePorts.GetBondPort(d.ID)
@@ -425,7 +425,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 	}
 
 	if nType != NetworkL3 {
-		t.Fatalf("the %s device should be back in network type L3", plan)
+		t.Fatal("the device now should be back in network type L3")
 	}
 
 }


### PR DESCRIPTION
Currently tests are not passed:

```
 $ go version
go version go1.10.1 darwin/amd64

 $ go test -v ./...      
./ports_test.go:219: Fatalf call has arguments but no formatting directives
./ports_test.go:369: Fatalf call has arguments but no formatting directives
FAIL	github.com/packethost/packngo [build failed]
?   	github.com/packethost/packngo/metadata	[no test files]
```

Fatalf with extra arguments
Removed argmunets for Fatalf methods without use it.
Tested should be fixed with it.

Also other proposal to change format string to:

```
t.Fatalf("The device %s should be in network type L2 Bonded", plan)
```

similar to https://github.com/packethost/packngo/blame/master/ports_test.go#L194

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/70)
<!-- Reviewable:end -->
