### PR TITLE
In Debug mode show requests and response labels

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -192,7 +192,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	response.populateRate()
 	if c.debug {
 		o, _ := httputil.DumpResponse(response.Response, true)
-		log.Printf("%s\n", string(o))
+		log.Printf("\n=======[RESPONSE]============\n%s\n\n", string(o))
 	}
 	c.RateLimit = response.Rate
 
@@ -223,7 +223,7 @@ func (c *Client) DoRequest(method, path string, body, v interface{}) (*Response,
 	req, err := c.NewRequest(method, path, body)
 	if c.debug {
 		o, _ := httputil.DumpRequestOut(req, true)
-		log.Printf("%s\n", string(o))
+		log.Printf("\n=======[REQUEST]=============\n%s\n", string(o))
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
To debug requests it is not easy to read debug information.
A new labels would mark requests or response

Sample:

```
=== RUN   TestAccOrg
2018/04/25 23:23:25 
=======[REQUEST]=============
POST /organizations HTTP/1.1
Host: api.packet.net
User-Agent: packngo/0.1.0
Connection: close
Content-Length: 141
Accept: application/json
Content-Type: application/json

{"name":"PACKNGO_TEST_DELME_2d768716_KDhWiJGz","description":"Managed by Packngo.","website":"http://example.com","twitter":"foo","logo":""}

2018/04/25 23:23:26 
=======[RESPONSE]============
HTTP/2.0 201 Created
Content-Length: 971
Cache-Control: max-age=0, private, must-revalidate
Content-Type: application/json; charset=utf-8
Server: nginx
Status: 201 Created
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/72)
<!-- Reviewable:end -->
