### PR TITLE
Add customdata support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 pipeline:
   lint:
-    image: golang:1.8
+    image: golang:1.9
     commands:
       - go get -v -u github.com/alecthomas/gometalinter
       - gometalinter --install
@@ -18,11 +18,11 @@ pipeline:
       - if ! $ok; then exit 1; fi
 
   build:
-    image: golang:1.8
+    image: golang:1.9
     commands:
       - go build -i -v ./...
 
   test:
-    image: golang:1.8
+    image: golang:1.9
     commands:
       - go test ./...

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ func main() {
 		log.Fatal(err)
 	}
 	for _, p := range ps {
-		log.Println(p.Name, p.ID)
+		log.Println(p.ID, p.Name)
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,49 @@ Packet Go Api Client
 
 ![](https://www.packet.net/media/labs/images/1679091c5a880faf6fb5e6087eb1b2dc/ULY7-hero.png)
 
-Committing
-----------
 
-Before committing, it's a good idea to run `gofmt -w *.go`. ([gofmt](https://golang.org/cmd/gofmt/))
+Installation
+------------
 
+`go get github.com/packethost/packngo`
 
 Usage
 -----
 
+To authenticate to the Packet API, you must have your API token exported in env var `PACKET_API_TOKEN`.
+
+This code snippet initializes Packet API client, and lists your Projects:
+
+```go
+package main
+
+import (
+	"log"
+
+	"github.com/packethost/packngo"
+)
+
+func main() {
+	c, err := packngo.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ps, _, err := c.Projects.List()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, p := range ps {
+		log.Println(p.Name, p.ID)
+	}
+}
+
+```
+
 This lib is used by the official [terraform-provider-packet](https://github.com/terraform-providers/terraform-provider-packet).
 
-If you want to use it in your Go code, you can learn a lot from the `*_test.go` sources. Almost all out tests touch the Packet API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
+You can also learn a lot from the `*_test.go` sources. Almost all out tests touch the Packet API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
+
 
 
 Acceptance Tests
@@ -22,14 +53,20 @@ Acceptance Tests
 
 If you want to run tests against the actual Packet API, you must set envvar `PACKET_TEST_ACTUAL_API` to non-empty string for the `go test`. The device tests wait for the device creation, so it's best to run a few in parallel.
 
-To run all the tests, you can do
-
-```
-$ PACKNGO_TEST_ACTUAL_API=1 go test -v -parallel 8
-```
-
-It's also useful to run only single acceptance test at a time:
+To run a particular test, you can do
 
 ```
 $ PACKNGO_TEST_ACTUAL_API=1 go test -v -run=TestAccDeviceBasic
 ```
+
+If you want to see HTTP requests, set the `PACKNGO_DEBUG` env var to non-empty string, for example:
+
+```
+$ PACKNGO_DEBUG=1 PACKNGO_TEST_ACTUAL_API=1 go test -v -run=TestAccVolumeUpdate
+```
+
+
+Committing
+----------
+
+Before committing, it's a good idea to run `gofmt -w *.go`. ([gofmt](https://golang.org/cmd/gofmt/))

--- a/devices.go
+++ b/devices.go
@@ -104,7 +104,7 @@ type DeviceUpdateRequest struct {
 	Tags          *[]string `json:"tags,omitempty"`
 	AlwaysPXE     *bool     `json:"always_pxe,omitempty"`
 	IPXEScriptURL *string   `json:"ipxe_script_url,omitempty"`
-	CustomData    string    `json:"customdata,omitempty"`
+	CustomData    *string   `json:"customdata,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {

--- a/devices.go
+++ b/devices.go
@@ -91,6 +91,7 @@ type DeviceCreateRequest struct {
 	SpotInstance          bool       `json:"spot_instance,omitempty"`
 	SpotPriceMax          float64    `json:"spot_price_max,omitempty,string"`
 	TerminationTime       *Timestamp `json:"termination_time,omitempty"`
+	CustomData            string     `json:"customdata,omitempty"`
 }
 
 // DeviceUpdateRequest type used to update a Packet device

--- a/devices.go
+++ b/devices.go
@@ -103,6 +103,7 @@ type DeviceUpdateRequest struct {
 	Tags          *[]string `json:"tags,omitempty"`
 	AlwaysPXE     *bool     `json:"always_pxe,omitempty"`
 	IPXEScriptURL *string   `json:"ipxe_script_url,omitempty"`
+	CustomData    string    `json:"customdata,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {

--- a/devices.go
+++ b/devices.go
@@ -56,6 +56,7 @@ type Device struct {
 	SpotPriceMax        float64                `json:"spot_price_max,omitempty"`
 	TerminationTime     *Timestamp             `json:"termination_time,omitempty"`
 	NetworkPorts        []Port                 `json:"network_ports,omitempty"`
+	CustomData          map[string]interface{} `json:"customdata,omitempty"`
 }
 
 type ProvisionEvent struct {

--- a/devices_test.go
+++ b/devices_test.go
@@ -3,7 +3,6 @@ package packngo
 import (
 	"errors"
 	"fmt"
-	"log"
 	"path"
 	"testing"
 	"time"
@@ -530,7 +529,6 @@ func TestAccDeviceCustomData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Println(device.CustomData)
 	if len(device.CustomData) != 0 {
 		t.Fatal(errors.New("Did not properly erase custom data"))
 	}

--- a/devices_test.go
+++ b/devices_test.go
@@ -3,6 +3,7 @@ package packngo
 import (
 	"errors"
 	"fmt"
+	"log"
 	"path"
 	"testing"
 	"time"
@@ -501,9 +502,12 @@ func TestAccDeviceCustomData(t *testing.T) {
 	}
 
 	updateCustomData := `{"hi":"earth"}`
-	c.Devices.Update(dID, &DeviceUpdateRequest{
+	_, _, err = c.Devices.Update(dID, &DeviceUpdateRequest{
 		CustomData: &updateCustomData,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	device, _, err = c.Devices.Get(dID)
 	if err != nil {
@@ -512,5 +516,22 @@ func TestAccDeviceCustomData(t *testing.T) {
 
 	if device.CustomData["hi"] != "earth" {
 		t.Fatal(errors.New("Did not properly update custom data"))
+	}
+
+	updateCustomData = ""
+	_, _, err = c.Devices.Update(dID, &DeviceUpdateRequest{
+		CustomData: &updateCustomData,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device, _, err = c.Devices.Get(dID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Println(device.CustomData)
+	if len(device.CustomData) != 0 {
+		t.Fatal(errors.New("Did not properly erase custom data"))
 	}
 }

--- a/devices_test.go
+++ b/devices_test.go
@@ -502,7 +502,7 @@ func TestAccDeviceCustomData(t *testing.T) {
 
 	updateCustomData := `{"hi":"earth"}`
 	c.Devices.Update(dID, &DeviceUpdateRequest{
-		CustomData: updateCustomData,
+		CustomData: &updateCustomData,
 	})
 
 	device, _, err = c.Devices.Get(dID)

--- a/packngo.go
+++ b/packngo.go
@@ -17,11 +17,12 @@ import (
 )
 
 const (
-	libraryVersion = "0.1.0"
-	baseURL        = "https://api.packet.net/"
-	userAgent      = "packngo/" + libraryVersion
-	mediaType      = "application/json"
-	debugEnvVar    = "PACKNGO_DEBUG"
+	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
+	libraryVersion    = "0.1.0"
+	baseURL           = "https://api.packet.net/"
+	userAgent         = "packngo/" + libraryVersion
+	mediaType         = "application/json"
+	debugEnvVar       = "PACKNGO_DEBUG"
 
 	headerRateLimit     = "X-RateLimit-Limit"
 	headerRateRemaining = "X-RateLimit-Remaining"
@@ -231,11 +232,21 @@ func (c *Client) DoRequest(method, path string, body, v interface{}) (*Response,
 	return c.Do(req, v)
 }
 
-// NewClient initializes and returns a Client, use this to get an API Client to operate on
+func NewClient() (*Client, error) {
+	apiToken := os.Getenv(packetTokenEnvVar)
+	if apiToken == "" {
+		return nil, fmt.Errorf("you must export %s.", packetTokenEnvVar)
+	}
+	c := NewClientWithAuth("packngo lib", apiToken, nil)
+	return c, nil
+
+}
+
+// NewClientWithAuth initializes and returns a Client, use this to get an API Client to operate on
 // N.B.: Packet's API certificate requires Go 1.5+ to successfully parse. If you are using
 // an older version of Go, pass in a custom http.Client with a custom TLS configuration
 // that sets "InsecureSkipVerify" to "true"
-func NewClient(consumerToken string, apiKey string, httpClient *http.Client) *Client {
+func NewClientWithAuth(consumerToken string, apiKey string, httpClient *http.Client) *Client {
 	client, _ := NewClientWithBaseURL(consumerToken, apiKey, httpClient, baseURL)
 	return client
 }

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
 	packetURLEnvVar   = "PACKET_API_URL"
 	packngoAccTestVar = "PACKNGO_TEST_ACTUAL_API"
 	testProjectPrefix = "PACKNGO_TEST_DELME_2d768716_"
@@ -107,7 +106,7 @@ func organizationTeardown(c *Client) {
 
 func TestAccInvalidCredentials(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
-	c := NewClient("packngo test", "wrongApiToken", nil)
+	c := NewClientWithAuth("packngo test", "wrongApiToken", nil)
 	_, r, expectedErr := c.Projects.List()
 	matched, err := regexp.MatchString(".*Invalid.*", expectedErr.Error())
 	if err != nil {


### PR DESCRIPTION
Ran modified versions of `TestAccDeviceBasic` and `TestAccDeviceUpdate` and the created/updated devices had the correct `customdata` set, didn't want to modify the tests themselves to keep them generic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/75)
<!-- Reviewable:end -->
