### PR TITLE
Passing missing CIDR parameter in path in function AvailableAddresses

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -182,7 +182,7 @@ func (i *ProjectIPServiceOp) Remove(ipReservationID string) (*Response, error) {
 
 // AvailableAddresses lists addresses available from a reserved block
 func (i *ProjectIPServiceOp) AvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error) {
-	path := fmt.Sprintf("%s/%s/available", ipBasePath, ipReservationID)
+	path := fmt.Sprintf("%s/%s/available?cidr=%d", ipBasePath, ipReservationID, r.CIDR)
 	ar := new(AvailableResponse)
 
 	resp, err := i.client.DoRequest("GET", path, r, ar)


### PR DESCRIPTION
`cidr=%d` wasn't passed to the API causing this error:
```
GET https://api.packet.net/ips/c59de42b-c30b-48e0-9955-801cf518319d/available: 422 Missing cidr parameter
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/80)
<!-- Reviewable:end -->
