### PR TITLE
add support for `customdata` in the metadata call

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -101,16 +101,17 @@ func (m BondingMode) String() string {
 }
 
 type CurrentDevice struct {
-	ID       string          `json:"id"`
-	Hostname string          `json:"hostname"`
-	IQN      string          `json:"iqn"`
-	Plan     string          `json:"plan"`
-	Facility string          `json:"facility"`
-	Tags     []string        `json:"tags"`
-	SSHKeys  []string        `json:"ssh_keys"`
-	OS       OperatingSystem `json:"operating_system"`
-	Network  NetworkInfo     `json:"network"`
-	Volumes  []VolumeInfo    `json:"volume"`
+	ID         string                 `json:"id"`
+	Hostname   string                 `json:"hostname"`
+	IQN        string                 `json:"iqn"`
+	Plan       string                 `json:"plan"`
+	Facility   string                 `json:"facility"`
+	Tags       []string               `json:"tags"`
+	SSHKeys    []string               `json:"ssh_keys"`
+	OS         OperatingSystem        `json:"operating_system"`
+	Network    NetworkInfo            `json:"network"`
+	Volumes    []VolumeInfo           `json:"volume"`
+	CustomData map[string]interface{} `json:"customdata"`
 
 	// This is available, but is actually inaccurate, currently:
 	//   APIBaseURL string          `json:"api_url"`


### PR DESCRIPTION
The metadata endpoing now also returns `customdata` which is a json blob

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/82)
<!-- Reviewable:end -->
