### PR TITLE
List projects

### DIFF
--- a/packngo_test.go
+++ b/packngo_test.go
@@ -75,7 +75,7 @@ func setup(t *testing.T) *Client {
 }
 
 func projectTeardown(c *Client) {
-	ps, _, err := c.Projects.List()
+	ps, _, err := c.Projects.List(nil)
 	if err != nil {
 		panic(fmt.Errorf("while teardown: %s", err))
 	}
@@ -107,7 +107,7 @@ func organizationTeardown(c *Client) {
 func TestAccInvalidCredentials(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	c := NewClientWithAuth("packngo test", "wrongApiToken", nil)
-	_, r, expectedErr := c.Projects.List()
+	_, r, expectedErr := c.Projects.List(nil)
 	matched, err := regexp.MatchString(".*Invalid.*", expectedErr.Error())
 	if err != nil {
 		t.Fatalf("Err while matching err string from response err %s: %s", expectedErr, err)

--- a/projects_test.go
+++ b/projects_test.go
@@ -152,11 +152,7 @@ func TestAccListProjects(t *testing.T) {
 
 	for _, proj := range projs {
 		if proj.ID == p.ID {
-			if len(proj.Users) == 0 {
-				t.Fatal("Project users not returned.")
-			}
-
-			if proj.Users[0].FirstName != u.FirstName {
+			if proj.Users[0].ID != u.ID {
 				t.Fatal("Project user details not returned.")
 			}
 			break

--- a/projects_test.go
+++ b/projects_test.go
@@ -118,7 +118,9 @@ func TestAccCreateNonDefaultOrgProject(t *testing.T) {
 }
 
 func TestAccListProjects(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
 	c := setup(t)
+
 	defer projectTeardown(c)
 
 	rs := testProjectPrefix + randString8()

--- a/projects_test.go
+++ b/projects_test.go
@@ -159,3 +159,46 @@ func TestAccListProjects(t *testing.T) {
 		}
 	}
 }
+
+func TestAccProjectListPagination(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	c := setup(t)
+	defer projectTeardown(c)
+	for i := 0; i < 3; i++ {
+		pcr := ProjectCreateRequest{
+			Name: testProjectPrefix + randString8(),
+		}
+		_, _, err := c.Projects.Create(&pcr)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	listOpts := &ListOptions{
+		Page:    1,
+		PerPage: 3,
+	}
+
+	projects, _, err := c.Projects.List(listOpts)
+	if err != nil {
+		t.Fatalf("failed to get list of projects: %v", err)
+	}
+	// The user account that runs this test probably have some projects on
+	// his own, keep it in mind when improving/extending this test.
+	if len(projects) != 3 {
+		t.Fatalf("exactly 3 projects should have been fetched: %v", err)
+	}
+
+	listOpts = &ListOptions{
+		Page:    2,
+		PerPage: 1,
+	}
+
+	projects, _, err = c.Projects.List(listOpts)
+	if err != nil {
+		t.Fatalf("failed to get list of projects: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("only 1 project should have been fetched: %v", err)
+	}
+
+}


### PR DESCRIPTION
Addressing issues referenced:
https://github.com/packethost/packet-cli/issues/5
https://github.com/packethost/packet-cli/issues/6

While working at this I noticed that is not really practical to use:

```
	projects, _, err := c.Projects.List(listOpt)
```
or if you don't want to have list options you have to do:

```
	projs, _, err := c.Projects.List(nil)
```

@vielmetti @t0mk what do you guys think if we use variadic args for example:

```
	List(args ...ListOptions) ([]Project, *Response, error)
```
This would allow us to have more elegant syntax when calling list without additional parameters:

```
	projs, _, err := c.Projects.List()
```
and the same syntax would be for the calls with additional parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/87)
<!-- Reviewable:end -->
