### PR TITLE
Capacities

### DIFF
--- a/capacities.go
+++ b/capacities.go
@@ -1,0 +1,93 @@
+package packngo
+
+const capacityBasePath = "/capacity"
+
+// CapacityService interface defines available capacity methods
+type CapacityService interface {
+	List() (*CapacityReport, *Response, error)
+	Check(*CapacityInput) (*Response, error)
+}
+
+// CapacityInput struct
+type CapacityInput struct {
+	Servers []ServerInfo `json:"servers,omitempty"`
+}
+
+// ServerInfo struct
+type ServerInfo struct {
+	Facility string `json:"facility,omitempty"`
+	Plan     string `json:"plan,omitempty"`
+	Quantity int    `json:"quantity,omitempty"`
+}
+
+type capacityRoot struct {
+	Capacity CapacityReport `json:"capacity,omitempty"`
+}
+
+// CapacityReport struct
+type CapacityReport struct {
+	Ams1 *CapacityPerFacility `json:"ams1,omitempty"`
+	Ewr1 *CapacityPerFacility `json:"ewr1,omitempty"`
+	Sjc1 *CapacityPerFacility `json:"sjc1,omitempty"`
+	Atl1 *CapacityPerFacility `json:"atl1,omitempty"`
+	Dfw1 *CapacityPerFacility `json:"dfw1,omitempty"`
+	Fra1 *CapacityPerFacility `json:"fra1,omitempty"`
+	Iad1 *CapacityPerFacility `json:"iad1,omitempty"`
+	Lax1 *CapacityPerFacility `json:"lax1,omitempty"`
+	Nrt1 *CapacityPerFacility `json:"nrt1,omitempty"`
+	Ord1 *CapacityPerFacility `json:"ord1,omitempty"`
+	Sea1 *CapacityPerFacility `json:"sea1,omitempty"`
+	Sin1 *CapacityPerFacility `json:"sin1,omitempty"`
+	Syd1 *CapacityPerFacility `json:"syd1,omitempty"`
+	Yyz1 *CapacityPerFacility `json:"yyz1,omitempty"`
+}
+
+// CapacityPerFacility struct
+type CapacityPerFacility struct {
+	T1SmallX86  *CapacityPerBaremetal `json:"t1.small.x86,omitempty"`
+	C1SmallX86  *CapacityPerBaremetal `json:"c1.small.x86,omitempty"`
+	M1XlargeX86 *CapacityPerBaremetal `json:"m1.xlarge.x86,omitempty"`
+	C1XlargeX86 *CapacityPerBaremetal `json:"c1.xlarge.x86,omitempty"`
+
+	Baremetal0   *CapacityPerBaremetal `json:"baremetal_0,omitempty"`
+	Baremetal1   *CapacityPerBaremetal `json:"baremetal_1,omitempty"`
+	Baremetal1e  *CapacityPerBaremetal `json:"baremetal_1e,omitempty"`
+	Baremetal2   *CapacityPerBaremetal `json:"baremetal_2,omitempty"`
+	Baremetal2a  *CapacityPerBaremetal `json:"baremetal_2a,omitempty"`
+	Baremetal2a2 *CapacityPerBaremetal `json:"baremetal_2a2,omitempty"`
+	Baremetal3   *CapacityPerBaremetal `json:"baremetal_3,omitempty"`
+}
+
+// CapacityPerBaremetal struct
+type CapacityPerBaremetal struct {
+	Level string `json:"level,omitempty"`
+}
+
+// CapacityList struct
+type CapacityList struct {
+	Capacity CapacityReport `json:"capacity,omitempty"`
+}
+
+// CapacityServiceOp implements CapacityService
+type CapacityServiceOp struct {
+	client *Client
+}
+
+// List returns a list of facilities and plans with their current capacity.
+func (s *CapacityServiceOp) List() (*CapacityReport, *Response, error) {
+	root := new(capacityRoot)
+
+	resp, err := s.client.DoRequest("GET", capacityBasePath, nil, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &root.Capacity, nil, nil
+}
+
+// Check validates if a deploy can be fulfilled.
+func (s *CapacityServiceOp) Check(input *CapacityInput) (resp *Response, err error) {
+
+	return s.client.DoRequest("POST", capacityBasePath, input, nil)
+
+}

--- a/capacities.go
+++ b/capacities.go
@@ -5,7 +5,7 @@ const capacityBasePath = "/capacity"
 // CapacityService interface defines available capacity methods
 type CapacityService interface {
 	List() (*CapacityReport, *Response, error)
-	Check(*CapacityInput) (*Response, error)
+	Check(*CapacityInput) (*CapacityInput, *Response, error)
 }
 
 // CapacityInput struct
@@ -15,9 +15,10 @@ type CapacityInput struct {
 
 // ServerInfo struct
 type ServerInfo struct {
-	Facility string `json:"facility,omitempty"`
-	Plan     string `json:"plan,omitempty"`
-	Quantity int    `json:"quantity,omitempty"`
+	Facility  string `json:"facility,omitempty"`
+	Plan      string `json:"plan,omitempty"`
+	Quantity  int    `json:"quantity,omitempty"`
+	Available bool   `json:"available,omitempty"`
 }
 
 type capacityRoot struct {
@@ -27,21 +28,21 @@ type capacityRoot struct {
 // CapacityReport map
 type CapacityReport map[string]map[string]CapacityPerBaremetal
 
-// CapacityPerFacility struct
-type CapacityPerFacility struct {
-	T1SmallX86  *CapacityPerBaremetal `json:"t1.small.x86,omitempty"`
-	C1SmallX86  *CapacityPerBaremetal `json:"c1.small.x86,omitempty"`
-	M1XlargeX86 *CapacityPerBaremetal `json:"m1.xlarge.x86,omitempty"`
-	C1XlargeX86 *CapacityPerBaremetal `json:"c1.xlarge.x86,omitempty"`
+// // CapacityPerFacility struct
+// type CapacityPerFacility struct {
+// 	T1SmallX86  *CapacityPerBaremetal `json:"t1.small.x86,omitempty"`
+// 	C1SmallX86  *CapacityPerBaremetal `json:"c1.small.x86,omitempty"`
+// 	M1XlargeX86 *CapacityPerBaremetal `json:"m1.xlarge.x86,omitempty"`
+// 	C1XlargeX86 *CapacityPerBaremetal `json:"c1.xlarge.x86,omitempty"`
 
-	Baremetal0   *CapacityPerBaremetal `json:"baremetal_0,omitempty"`
-	Baremetal1   *CapacityPerBaremetal `json:"baremetal_1,omitempty"`
-	Baremetal1e  *CapacityPerBaremetal `json:"baremetal_1e,omitempty"`
-	Baremetal2   *CapacityPerBaremetal `json:"baremetal_2,omitempty"`
-	Baremetal2a  *CapacityPerBaremetal `json:"baremetal_2a,omitempty"`
-	Baremetal2a2 *CapacityPerBaremetal `json:"baremetal_2a2,omitempty"`
-	Baremetal3   *CapacityPerBaremetal `json:"baremetal_3,omitempty"`
-}
+// 	Baremetal0   *CapacityPerBaremetal `json:"baremetal_0,omitempty"`
+// 	Baremetal1   *CapacityPerBaremetal `json:"baremetal_1,omitempty"`
+// 	Baremetal1e  *CapacityPerBaremetal `json:"baremetal_1e,omitempty"`
+// 	Baremetal2   *CapacityPerBaremetal `json:"baremetal_2,omitempty"`
+// 	Baremetal2a  *CapacityPerBaremetal `json:"baremetal_2a,omitempty"`
+// 	Baremetal2a2 *CapacityPerBaremetal `json:"baremetal_2a2,omitempty"`
+// 	Baremetal3   *CapacityPerBaremetal `json:"baremetal_3,omitempty"`
+// }
 
 // CapacityPerBaremetal struct
 type CapacityPerBaremetal struct {
@@ -71,8 +72,8 @@ func (s *CapacityServiceOp) List() (*CapacityReport, *Response, error) {
 }
 
 // Check validates if a deploy can be fulfilled.
-func (s *CapacityServiceOp) Check(input *CapacityInput) (resp *Response, err error) {
-
-	return s.client.DoRequest("POST", capacityBasePath, input, nil)
-
+func (s *CapacityServiceOp) Check(input *CapacityInput) (cap *CapacityInput, resp *Response, err error) {
+	cap = new(CapacityInput)
+	resp, err = s.client.DoRequest("POST", capacityBasePath, input, cap)
+	return cap, resp, err
 }

--- a/capacities.go
+++ b/capacities.go
@@ -24,23 +24,8 @@ type capacityRoot struct {
 	Capacity CapacityReport `json:"capacity,omitempty"`
 }
 
-// CapacityReport struct
-type CapacityReport struct {
-	Ams1 *CapacityPerFacility `json:"ams1,omitempty"`
-	Ewr1 *CapacityPerFacility `json:"ewr1,omitempty"`
-	Sjc1 *CapacityPerFacility `json:"sjc1,omitempty"`
-	Atl1 *CapacityPerFacility `json:"atl1,omitempty"`
-	Dfw1 *CapacityPerFacility `json:"dfw1,omitempty"`
-	Fra1 *CapacityPerFacility `json:"fra1,omitempty"`
-	Iad1 *CapacityPerFacility `json:"iad1,omitempty"`
-	Lax1 *CapacityPerFacility `json:"lax1,omitempty"`
-	Nrt1 *CapacityPerFacility `json:"nrt1,omitempty"`
-	Ord1 *CapacityPerFacility `json:"ord1,omitempty"`
-	Sea1 *CapacityPerFacility `json:"sea1,omitempty"`
-	Sin1 *CapacityPerFacility `json:"sin1,omitempty"`
-	Syd1 *CapacityPerFacility `json:"syd1,omitempty"`
-	Yyz1 *CapacityPerFacility `json:"yyz1,omitempty"`
-}
+// CapacityReport map
+type CapacityReport map[string]map[string]CapacityPerBaremetal
 
 // CapacityPerFacility struct
 type CapacityPerFacility struct {

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -32,7 +32,7 @@ func TestAccCheckCapacity(t *testing.T) {
 
 	list, _, err := c.CapacityService.List()
 	if err != nil {
-		t.Fatal("List of capacities not fetched")
+		t.Fatal(err)
 	}
 
 	for k, v := range *list {

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccCheckCapacity(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
 	c := setup(t)
 
 	input := &CapacityInput{
@@ -29,7 +30,7 @@ func TestAccCheckCapacity(t *testing.T) {
 		t.Fatal("List of capacities not fetched")
 	}
 
-	// Getting facility where a plan is unavailable 
+	// Getting facility where a plan is unavailable
 	s := reflect.ValueOf(list).Elem()
 	typeOfT := s.Type()
 	for i := 0; i < s.NumField(); i++ {

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -37,14 +37,14 @@ func TestAccCheckCapacity(t *testing.T) {
 
 	for k, v := range *list {
 		if v["baremetal_2a2"].Level == "unavailable" {
-			input.Servers[0].Plan = v["baremetal_2a2"].Level
+			input.Servers[0].Plan = "baremetal_2a2"
 			input.Servers[0].Facility = k
 			break
 		}
 	}
 
 	cap, _, err = c.CapacityService.Check(input)
-	if err == nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -1,9 +1,6 @@
 package packngo
 
 import (
-	"fmt"
-	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -20,7 +17,7 @@ func TestAccCheckCapacity(t *testing.T) {
 		},
 	}
 
-	resp, err := c.CapacityService.Check(input)
+	_, err := c.CapacityService.Check(input)
 	if err != nil {
 		t.Fatal("Requested check should have passed for:", input.Servers[0].Facility, input.Servers[0].Plan, input.Servers[0].Quantity)
 	}
@@ -30,20 +27,16 @@ func TestAccCheckCapacity(t *testing.T) {
 		t.Fatal("List of capacities not fetched")
 	}
 
-	// Getting facility where a plan is unavailable
-	s := reflect.ValueOf(list).Elem()
-	typeOfT := s.Type()
-	for i := 0; i < s.NumField(); i++ {
-		f := s.Field(i).Interface().(*CapacityPerFacility)
-		if f.Baremetal2a2 != nil && f.Baremetal2a2.Level == "unavailable" {
-			input.Servers[0].Plan = f.Baremetal2a2.Level
-			input.Servers[0].Facility = strings.ToLower(typeOfT.Field(i).Name)
+	for k, v := range *list {
+		if v["baremetal_2a2"].Level == "unavailable" {
+			input.Servers[0].Plan = v["baremetal_2a2"].Level
+			input.Servers[0].Facility = k
+			break
 		}
 	}
 
-	resp, err = c.CapacityService.Check(input)
+	_, err = c.CapacityService.Check(input)
 	if err == nil {
 		t.Fatal("Requested check should have failed for:", input.Servers[0].Facility, input.Servers[0].Plan, input.Servers[0].Quantity)
 	}
-	fmt.Println(resp)
 }

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -1,0 +1,48 @@
+package packngo
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAccCheckCapacity(t *testing.T) {
+	c := setup(t)
+
+	input := &CapacityInput{
+		[]ServerInfo{
+			{
+				Facility: "ams1",
+				Plan:     "baremetal_0",
+				Quantity: 1},
+		},
+	}
+
+	resp, err := c.CapacityService.Check(input)
+	if err != nil {
+		t.Fatal("Requested check should have passed for:", input.Servers[0].Facility, input.Servers[0].Plan, input.Servers[0].Quantity)
+	}
+
+	list, _, err := c.CapacityService.List()
+	if err != nil {
+		t.Fatal("List of capacities not fetched")
+	}
+
+	// Getting facility where a plan is unavailable 
+	s := reflect.ValueOf(list).Elem()
+	typeOfT := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i).Interface().(*CapacityPerFacility)
+		if f.Baremetal2a2 != nil && f.Baremetal2a2.Level == "unavailable" {
+			input.Servers[0].Plan = f.Baremetal2a2.Level
+			input.Servers[0].Facility = strings.ToLower(typeOfT.Field(i).Name)
+		}
+	}
+
+	resp, err = c.CapacityService.Check(input)
+	if err == nil {
+		t.Fatal("Requested check should have failed for:", input.Servers[0].Facility, input.Servers[0].Plan, input.Servers[0].Quantity)
+	}
+	fmt.Println(resp)
+}

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -1,6 +1,7 @@
 package packngo
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -17,9 +18,16 @@ func TestAccCheckCapacity(t *testing.T) {
 		},
 	}
 
-	_, err := c.CapacityService.Check(input)
+	cap, _, err := c.CapacityService.Check(input)
 	if err != nil {
-		t.Fatal("Requested check should have passed for:", input.Servers[0].Facility, input.Servers[0].Plan, input.Servers[0].Quantity)
+		t.Fatal(err)
+	}
+
+	for _, s := range cap.Servers {
+		if !s.Available {
+			t.Fatal(fmt.Errorf("Capacity of %d severs should have been available.", input.Servers[0].Quantity))
+			break
+		}
 	}
 
 	list, _, err := c.CapacityService.List()
@@ -35,8 +43,15 @@ func TestAccCheckCapacity(t *testing.T) {
 		}
 	}
 
-	_, err = c.CapacityService.Check(input)
+	cap, _, err = c.CapacityService.Check(input)
 	if err == nil {
-		t.Fatal("Requested check should have failed for:", input.Servers[0].Facility, input.Servers[0].Plan, input.Servers[0].Quantity)
+		t.Fatal(err)
+	}
+
+	for _, s := range cap.Servers {
+		if s.Available {
+			t.Fatal(fmt.Errorf("Capacity of %d severs should not have been available.", input.Servers[0].Quantity))
+			break
+		}
 	}
 }

--- a/packngo.go
+++ b/packngo.go
@@ -143,6 +143,7 @@ type Client struct {
 	VolumeAttachments      VolumeAttachmentService
 	SpotMarket             SpotMarketService
 	Organizations          OrganizationService
+	CapacityService        CapacityService
 }
 
 // NewRequest inits a new http request with the proper headers
@@ -284,7 +285,8 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.Volumes = &VolumeServiceOp{client: c}
 	c.VolumeAttachments = &VolumeAttachmentServiceOp{client: c}
 	c.SpotMarket = &SpotMarketServiceOp{client: c}
-
+	c.SpotMarket = &SpotMarketServiceOp{client: c}
+	c.CapacityService = &CapacityServiceOp{client: c}
 	return c, nil
 }
 


### PR DESCRIPTION
I implemented this feature a little bit differently then it is described [here](https://www.packet.net/developers/api/capacity/). Specifically **GET /capacity** does not return JSON from the example but slightly different one (see example below).

```
{"capacity":{
"ams1":{"baremetal_2a":{"level":"limited"},"baremetal_2a2":{"level":"unavailable"},"baremetal_1":{"level":"limited"},"baremetal_3":{"level":"unavailable"},"c2.medium.x86":{"level":"limited"},"baremetal_2":{"level":"limited"},"m2.xlarge.x86":{"level":"limited"},"baremetal_s":{"level":"limited"},"baremetal_0":{"level":"normal"}},
"atl1":{"baremetal_1e":{"level":"normal"}},
...
```
Unclear is whether all accounts will return same facilities with same plans so I mapped all of them in order to avoid mix up. 

Also while testing I found out that  check function **POST /capacity** doesn't behave as described in the docs. When failing it returns error _503 Service Unavailable_ where it is supposed to return _422 Unprocessable_ entity. This is not causing any problems for the tests to pass

//cc @mberrueta

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/91)
<!-- Reviewable:end -->
