### PR TITLE
Hardware reservations

### DIFF
--- a/hardware_reservations.go
+++ b/hardware_reservations.go
@@ -24,7 +24,7 @@ type HardwareReservation struct {
 	Plan      Plan      `json:"plan,omitempty"`
 	Href      string    `json:"href,omitempty"`
 	Project   Project   `json:"project,omitempty"`
-	Device    Device    `json:"device,omitempty"`
+	Device    *Device   `json:"device,omitempty"`
 	CreatedAt Timestamp `json:"created_at,omitempty"`
 }
 
@@ -87,7 +87,7 @@ func (s *HardwareReservationServiceOp) Get(hardwareReservationdID string, listOp
 // Move a hardware reservation to another project
 func (s *HardwareReservationServiceOp) Move(hardwareReservationdID, projectID string) (*HardwareReservation, *Response, error) {
 	hardwareReservation := new(HardwareReservation)
-	path := fmt.Sprintf("%s/%s%s", hardwareReservationBasePath, hardwareReservationdID, "move/")
+	path := fmt.Sprintf("%s/%s/%s", hardwareReservationBasePath, hardwareReservationdID, "move")
 	body := map[string]string{}
 	body["project_id"] = projectID
 

--- a/hardware_reservations.go
+++ b/hardware_reservations.go
@@ -1,0 +1,100 @@
+package packngo
+
+import "fmt"
+
+const hardwareReservationBasePath = "/hardware-reservations"
+
+// HardwareReservationService interface defines available hardware reservation functions
+type HardwareReservationService interface {
+	Get(string, listOpt *ListOptions) (*HardwareReservation, Response, error)
+	List(string, listOpt *ListOptions) ([]HardwareReservation, Response, error)
+	Move(string, string) (*HardwareReservation, Response, error)
+}
+
+// HardwareReservationServiceOp implements HardwareReservationService
+type HardwareReservationServiceOp struct {
+	client *Client
+}
+
+// HardwareReservation struct
+type HardwareReservation struct {
+	ID        string    `json:"id,omitempty"`
+	ShortID   string    `json:"short_id,omitempty"`
+	Facility  Facility  `json:"facility,omitempty"`
+	Plan      Plan      `json:"plan,omitempty"`
+	Href      string    `json:"href,omitempty"`
+	Project   Project   `json:"project,omitempty"`
+	Device    Device    `json:"device,omitempty"`
+	CreatedAt Timestamp `json:"created_at,omitempty"`
+}
+
+type hardwareReservationRoot struct {
+	HardwareReservations []HardwareReservation `json:"hardware_reservations"`
+	Meta                 meta                  `json:"meta"`
+}
+
+// List returns all hardware reservations for a given project
+func (s *HardwareReservationServiceOp) List(projectID string, listOpt *ListOptions) (reservations []HardwareReservation, resp *Response, err error) {
+	root := new(hardwareReservationRoot)
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	path := fmt.Sprintf("%s/%s%s?%s", projectBasePath, projectID, hardwareReservationBasePath, params)
+
+	for {
+		subset := new(hardwareReservationRoot)
+
+		resp, err = s.client.DoRequest("GET", path, nil, root)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		reservations = append(reservations, root.HardwareReservations...)
+
+		if subset.Meta.Next != nil && (listOpt == nil || listOpt.Page == 0) {
+			path = subset.Meta.Next.Href
+			if params != "" {
+				path = fmt.Sprintf("%s&%s", path, params)
+			}
+			continue
+		}
+
+		return
+	}
+}
+
+// Get returns a single hardware reservation
+func (s *HardwareReservationServiceOp) Get(hardwareReservationdID string, listOpt *ListOptions) (*HardwareReservation, *Response, error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	hardwareReservation := new(HardwareReservation)
+
+	path := fmt.Sprintf("%s/%s?%s", hardwareReservationBasePath, hardwareReservationdID, params)
+
+	resp, err := s.client.DoRequest("GET", path, nil, hardwareReservation)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hardwareReservation, resp, err
+}
+
+// Move a hardware reservation to another project
+func (s *HardwareReservationServiceOp) Move(hardwareReservationdID, projectID string) (*HardwareReservation, *Response, error) {
+	hardwareReservation := new(HardwareReservation)
+	path := fmt.Sprintf("%s/%s%s", hardwareReservationBasePath, hardwareReservationdID, "move/")
+	body := map[string]string{}
+	body["project_id"] = projectID
+
+	resp, err := s.client.DoRequest("POST", path, body, hardwareReservation)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hardwareReservation, resp, err
+}

--- a/hardware_reservations.go
+++ b/hardware_reservations.go
@@ -6,9 +6,9 @@ const hardwareReservationBasePath = "/hardware-reservations"
 
 // HardwareReservationService interface defines available hardware reservation functions
 type HardwareReservationService interface {
-	Get(string, listOpt *ListOptions) (*HardwareReservation, Response, error)
-	List(string, listOpt *ListOptions) ([]HardwareReservation, Response, error)
-	Move(string, string) (*HardwareReservation, Response, error)
+	Get(hardwareReservationID string, listOpt *ListOptions) (*HardwareReservation, *Response, error)
+	List(projectID string, listOpt *ListOptions) ([]HardwareReservation, *Response, error)
+	Move(string, string) (*HardwareReservation, *Response, error)
 }
 
 // HardwareReservationServiceOp implements HardwareReservationService

--- a/hardware_reservations_test.go
+++ b/hardware_reservations_test.go
@@ -1,0 +1,28 @@
+package packngo
+
+import (
+	"testing"
+)
+
+func TestAccListHardwareReservations(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	c := setup(t)
+
+	projectID := "93125c2a-8b78-4d4f-a3c4-7367d6b7cca8"
+	hardwareReservations, _, err := c.HardwareReservations.List(projectID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hrID := hardwareReservations[0].ID
+
+	hardwareReservation, _, err := c.HardwareReservations.Get(hrID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hardwareReservation.ID != hrID {
+		t.Fatal("Hardware reservation IDs don't match.")
+	}
+
+}

--- a/hardware_reservations_test.go
+++ b/hardware_reservations_test.go
@@ -8,7 +8,17 @@ func TestAccListHardwareReservations(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	c := setup(t)
 
-	projectID := "93125c2a-8b78-4d4f-a3c4-7367d6b7cca8"
+	projects, _, err := c.Projects.List(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(projects) == 0 {
+		t.Fatal("No projects returned.")
+	}
+
+	projectID := projects[0].ID
+
 	hardwareReservations, _, err := c.HardwareReservations.List(projectID, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/hardware_reservations_test.go
+++ b/hardware_reservations_test.go
@@ -6,33 +6,14 @@ import (
 
 func TestAccListHardwareReservations(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
-	c := setup(t)
-
-	projects, _, err := c.Projects.List(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(projects) == 0 {
-		t.Fatal("No projects returned.")
-	}
-
-	projectID := projects[0].ID
+	c, projectID, tearDown := setupWithProject(t)
+	defer tearDown()
 
 	hardwareReservations, _, err := c.HardwareReservations.List(projectID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	hrID := hardwareReservations[0].ID
-
-	hardwareReservation, _, err := c.HardwareReservations.Get(hrID, nil)
-	if err != nil {
-		t.Fatal(err)
+	if len(hardwareReservations) != 0 {
+		t.Fatal("There should not be any hardware reservations.")
 	}
-
-	if hardwareReservation.ID != hrID {
-		t.Fatal("Hardware reservation IDs don't match.")
-	}
-
 }

--- a/packngo.go
+++ b/packngo.go
@@ -143,6 +143,7 @@ type Client struct {
 	VolumeAttachments      VolumeAttachmentService
 	SpotMarket             SpotMarketService
 	Organizations          OrganizationService
+	HardwareReservations   HardwareReservationService
 }
 
 // NewRequest inits a new http request with the proper headers
@@ -284,7 +285,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.Volumes = &VolumeServiceOp{client: c}
 	c.VolumeAttachments = &VolumeAttachmentServiceOp{client: c}
 	c.SpotMarket = &SpotMarketServiceOp{client: c}
-
+	c.HardwareReservations = &HardwareReservationServiceOp{client: c}
 	return c, nil
 }
 


### PR DESCRIPTION
It is not possible to create a hardware reservation programatically so this feature is untested and doesn't contain unit tests.

@vielmetti would it be possible to create a single hardware reservation for our test account so we at least could test it. 

I already chatted with @mberrueta about another issue I found. Move operation is not documented properly:
![image](https://user-images.githubusercontent.com/8327751/43198620-99a27060-900f-11e8-9a4c-19c2bdea0dac.png)

Actually it is supposed to be a request body containing project_id property.
```
{
    "project_id" : [project_id]
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/98)
<!-- Reviewable:end -->
