### PR TITLE
fix required os variable in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 Usage
 -----
 
-To authenticate to the Packet API, you must have your API token exported in env var `PACKET_API_TOKEN`.
+To authenticate to the Packet API, you must have your API token exported in env var `PACKET_AUTH_TOKEN`.
 
 This code snippet initializes Packet API client, and lists your Projects:
 


### PR DESCRIPTION
After running the demo in the Readme, it looks like the env var is now `PACKET_AUTH_TOKEN` not `PACKET_API_TOKEN`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/113)
<!-- Reviewable:end -->
