### PR TITLE
Fix API Inconsistencies with packngo.Plan

### DIFF
--- a/plans.go
+++ b/plans.go
@@ -13,13 +13,15 @@ type planRoot struct {
 
 // Plan represents a Packet service plan
 type Plan struct {
-	ID          string   `json:"id"`
-	Slug        string   `json:"slug,omitempty"`
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Line        string   `json:"line,omitempty"`
-	Specs       *Specs   `json:"specs,omitempty"`
-	Pricing     *Pricing `json:"pricing,omitempty"`
+	ID              string   `json:"id"`
+	Slug            string   `json:"slug,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	Line            string   `json:"line,omitempty"`
+	Specs           *Specs   `json:"specs,omitempty"`
+	Pricing         *Pricing `json:"pricing"`
+	DeploymentTypes []string `json:"deployment_types"`
+	Class           string   `json:"class"`
 }
 
 func (p Plan) String() string {
@@ -91,8 +93,8 @@ func (f Features) String() string {
 
 // Pricing - the pricing options on a plan
 type Pricing struct {
-	Hourly  float32 `json:"hourly,omitempty"`
-	Monthly float32 `json:"monthly,omitempty"`
+	Hour  float32 `json:"hour,omitempty"`
+	Month float32 `json:"month,omitempty"`
 }
 
 func (p Pricing) String() string {

--- a/plans.go
+++ b/plans.go
@@ -1,6 +1,12 @@
 package packngo
 
+import (
+	"regexp"
+)
+
 const planBasePath = "/plans"
+
+var facilitiesRegex = regexp.MustCompile(`\/facilities\/([a-z0-9\-]+)$`)
 
 // PlanService interface defines available plan methods
 type PlanService interface {
@@ -13,15 +19,16 @@ type planRoot struct {
 
 // Plan represents a Packet service plan
 type Plan struct {
-	ID              string   `json:"id"`
-	Slug            string   `json:"slug,omitempty"`
-	Name            string   `json:"name,omitempty"`
-	Description     string   `json:"description,omitempty"`
-	Line            string   `json:"line,omitempty"`
-	Specs           *Specs   `json:"specs,omitempty"`
-	Pricing         *Pricing `json:"pricing"`
-	DeploymentTypes []string `json:"deployment_types"`
-	Class           string   `json:"class"`
+	ID              string              `json:"id"`
+	Slug            string              `json:"slug,omitempty"`
+	Name            string              `json:"name,omitempty"`
+	Description     string              `json:"description,omitempty"`
+	Line            string              `json:"line,omitempty"`
+	Specs           *Specs              `json:"specs,omitempty"`
+	Pricing         *Pricing            `json:"pricing,omitempty"`
+	DeploymentTypes []string            `json:"deployment_types"`
+	Class           string              `json:"class"`
+	AvailableIn     AvailableFacilities `json:"available_in"`
 }
 
 func (p Plan) String() string {
@@ -99,6 +106,25 @@ type Pricing struct {
 
 func (p Pricing) String() string {
 	return Stringify(p)
+}
+
+// Available facilities - the facilities a plan can exist in
+type AvailableFacilities []Reference
+
+type Reference struct {
+	Href string `json:"href"`
+}
+
+func (af AvailableFacilities) Ids() (ids []string) {
+	for _, v := range af {
+		match := facilitiesRegex.FindStringSubmatch(v.Href)
+
+		if len(match) == 2 {
+			ids = append(ids, match[1])
+		}
+	}
+
+	return ids
 }
 
 // PlanServiceOp implements PlanService

--- a/plans_test.go
+++ b/plans_test.go
@@ -1,0 +1,43 @@
+package packngo
+
+import (
+	"log"
+	"testing"
+)
+
+func TestAccPlans(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+
+	c := setup(t)
+	l, _, err := c.Plans.List(&ListOptions{Includes: []string{"available_in"}})
+
+	avail := map[string][]string{}
+	for _, p := range l {
+		for _, f := range p.AvailableIn {
+			if _, ok := avail[f.Code]; !ok {
+				avail[f.Code] = []string{p.Slug}
+			} else {
+				avail[f.Code] = append(avail[f.Code], p.Slug)
+			}
+		}
+		if p.Pricing.Hour > 0.0 {
+			t.Fatalf("strange pricing for %+v", p)
+		}
+	}
+
+	for f, ps := range avail {
+		if len(ps) == 0 {
+			t.Fatalf("no plans available in facility %s", f)
+		}
+		// prints plans available in facility
+		log.Printf("%s: %+v\n", f, ps)
+	}
+
+	if len(l) == 0 {
+		t.Fatal("Empty plans listing from the API")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Packet's API now uses `pricing.hour` instead of `pricing.hourly`. Additionally, the API now returns `class` and `deployment_types` which were missing from the Packngo client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/118)
<!-- Reviewable:end -->
