### PR TITLE
Allow for global_ipv4 in floating IP reservation, tests

### DIFF
--- a/devices_test.go
+++ b/devices_test.go
@@ -209,6 +209,125 @@ func TestAccDevicePXE(t *testing.T) {
 	}
 }
 
+func TestAccDeviceAssignGlobalIP(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	t.Parallel()
+
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+	hn := randString8()
+
+	fac := testFacility()
+
+	cr := DeviceCreateRequest{
+		Hostname:     hn,
+		Facility:     []string{fac},
+		Plan:         "baremetal_0",
+		ProjectID:    projectID,
+		BillingCycle: "hourly",
+		OS:           "ubuntu_16_04",
+	}
+
+	d, _, err := c.Devices.Create(&cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleteDevice(t, c, d.ID)
+
+	d, err = waitDeviceActive(d.ID, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := IPReservationRequest{
+		Type:     "global_ipv4",
+		Quantity: 1,
+		Comments: "packngo test",
+	}
+
+	reservation, _, err := c.ProjectIPs.Request(projectID, &req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	af := AddressStruct{Address: fmt.Sprintf("%s/%d", reservation.Address, reservation.CIDR)}
+
+	assignment, _, err := c.DeviceIPs.Assign(d.ID, &af)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if assignment.Management {
+		t.Error("Management flag for assignment resource must be False")
+	}
+
+	d, _, err = c.Devices.Get(d.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// If the Quantity in the IPReservationRequest is >1, this test won't work.
+	// The assignment CIDR would then have to be extracted from the reserved
+	// block.
+	reservation, _, err = c.ProjectIPs.Get(reservation.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(reservation.Assignments) != 1 {
+		t.Fatalf("reservation %s should have exactly 1 assignment", reservation)
+	}
+
+	if reservation.Assignments[0].Href != assignment.Href {
+		t.Fatalf("assignment %s should be listed in reservation resource %s",
+			assignment.Href, reservation)
+
+	}
+
+	func() {
+		for _, ipa := range d.Network {
+			if ipa.Href == assignment.Href {
+				return
+			}
+		}
+		t.Fatalf("assignment %s should be listed in device %s", assignment, d)
+	}()
+
+	if assignment.AssignedTo.Href != d.Href {
+		t.Fatalf("device %s should be listed in assignment %s",
+			d, assignment)
+	}
+
+	_, err = c.DeviceIPs.Unassign(assignment.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reload reservation, now without any assignment
+	reservation, _, err = c.ProjectIPs.Get(reservation.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(reservation.Assignments) != 0 {
+		t.Fatalf("reservation %s shoud be without assignments. Was %v",
+			reservation, reservation.Assignments)
+	}
+
+	// reload device, now without the assigned floating IP
+	d, _, err = c.Devices.Get(d.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, ipa := range d.Network {
+		if ipa.Href == assignment.Href {
+			t.Fatalf("assignment %s shoud be not listed in device %s anymore",
+				assignment, d)
+		}
+	}
+}
+
 func TestAccDeviceAssignIP(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	t.Parallel()
@@ -243,7 +362,7 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		Type:     "public_ipv4",
 		Quantity: 1,
 		Comments: "packngo test",
-		Facility: fac,
+		Facility: &fac,
 	}
 
 	reservation, _, err := c.ProjectIPs.Request(projectID, &req)

--- a/devices_test.go
+++ b/devices_test.go
@@ -284,14 +284,12 @@ func TestAccDeviceAssignGlobalIP(t *testing.T) {
 
 	}
 
-	func() {
-		for _, ipa := range d.Network {
-			if ipa.Href == assignment.Href {
-				return
-			}
+	for _, ipa := range d.Network {
+		if ipa.Href == assignment.Href {
+			return
 		}
-		t.Fatalf("assignment %s should be listed in device %s", assignment, d)
-	}()
+	}
+	t.Fatalf("assignment %s should be listed in device %s", assignment, d)
 
 	if assignment.AssignedTo.Href != d.Href {
 		t.Fatalf("device %s should be listed in assignment %s",
@@ -404,14 +402,12 @@ func TestAccDeviceAssignIP(t *testing.T) {
 
 	}
 
-	func() {
-		for _, ipa := range d.Network {
-			if ipa.Href == assignment.Href {
-				return
-			}
+	for _, ipa := range d.Network {
+		if ipa.Href == assignment.Href {
+			return
 		}
-		t.Fatalf("assignment %s should be listed in device %s", assignment, d)
-	}()
+	}
+	t.Fatalf("assignment %s should be listed in device %s", assignment, d)
 
 	if assignment.AssignedTo.Href != d.Href {
 		t.Fatalf("device %s should be listed in assignment %s",

--- a/ip.go
+++ b/ip.go
@@ -42,11 +42,11 @@ type ipAddressCommon struct {
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).
 type IPAddressReservation struct {
 	ipAddressCommon
-	Assignments []Href   `json:"assignments"`
-	Facility    Facility `json:"facility,omitempty"`
-	Available   string   `json:"available"`
-	Addon       bool     `json:"addon"`
-	Bill        bool     `json:"bill"`
+	Assignments []Href    `json:"assignments"`
+	Facility    *Facility `json:"facility,omitempty"`
+	Available   string    `json:"available"`
+	Addon       bool      `json:"addon"`
+	Bill        bool      `json:"bill"`
 }
 
 // AvailableResponse is a type for listing of available addresses from a reserved block.
@@ -67,10 +67,10 @@ type IPAddressAssignment struct {
 
 // IPReservationRequest represents the body of a reservation request.
 type IPReservationRequest struct {
-	Type     string `json:"type"`
-	Quantity int    `json:"quantity"`
-	Comments string `json:"comments"`
-	Facility string `json:"facility"`
+	Type     string  `json:"type"`
+	Quantity int     `json:"quantity"`
+	Comments string  `json:"comments"`
+	Facility *string `json:"facility,omitempty"`
 }
 
 // AddressStruct is a helper type for request/response with dict like {"address": ... }

--- a/ip_test.go
+++ b/ip_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestAccIPReservation(t *testing.T) {
+func TestAccPublicIPReservation(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 
 	c, projectID, teardown := setupWithProject(t)
@@ -29,7 +29,7 @@ func TestAccIPReservation(t *testing.T) {
 		Type:     "public_ipv4",
 		Quantity: quantity,
 		Comments: "packngo test",
-		Facility: testFac,
+		Facility: &testFac,
 	}
 
 	res, _, err := c.ProjectIPs.Request(projectID, &req)
@@ -54,6 +54,90 @@ func TestAccIPReservation(t *testing.T) {
 		t.Fatalf(
 			"Facility of new reservation should be %s, was %s", testFac,
 			res.Facility.Code)
+	}
+
+	ipList, _, err = c.ProjectIPs.List(projectID)
+	if len(ipList) != 1 {
+		t.Fatalf("There should be only one reservation, was: %s", ipList)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sameRes, _, err := c.ProjectIPs.Get(res.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sameRes.ID != res.ID {
+		t.Fatalf("re-requested test reservation should be %s, is %s",
+			res, sameRes)
+	}
+
+	availableAddresses, _, err := c.ProjectIPs.AvailableAddresses(
+		res.ID, &AvailableRequest{CIDR: 32})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(availableAddresses) != quantity {
+		t.Fatalf("New block should have %d available addresses, got %s",
+			quantity, availableAddresses)
+	}
+
+	_, err = c.ProjectIPs.Remove(res.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = c.ProjectIPs.Get(res.ID, nil)
+	if err == nil {
+		t.Fatalf("Reservation %s should be deleted at this point", res)
+	}
+}
+
+func TestAccGlobalIPReservation(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+	quantityToMask := map[int]int{
+		1: 32, 2: 31, 4: 30, 8: 29, 16: 28,
+	}
+
+	quantity := 1
+
+	ipList, _, err := c.ProjectIPs.List(projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ipList) != 0 {
+		t.Fatalf("There should be no reservations a new project, existing list: %s", ipList)
+	}
+
+	req := IPReservationRequest{
+		Type:     "global_ipv4",
+		Quantity: quantity,
+		Comments: "packngo test",
+	}
+
+	res, _, err := c.ProjectIPs.Request(projectID, &req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.CIDR != quantityToMask[quantity] {
+		t.Fatalf(
+			"CIDR prefix length for requested reservation should be %d, was %d",
+			quantityToMask[quantity], res.CIDR)
+	}
+
+	if path.Base(res.Project.Href) != projectID {
+		t.Fatalf("Wrong project linked in reserved block: %s", res.Project.Href)
+	}
+
+	if res.Management {
+		t.Fatal("Management flag of new reservation block must be False")
+	}
+	if res.Facility != nil {
+		t.Fatalf("Facility of new reservation should be nil")
 	}
 
 	ipList, _, err = c.ProjectIPs.List(projectID)

--- a/ip_test.go
+++ b/ip_test.go
@@ -136,16 +136,17 @@ func TestAccGlobalIPReservation(t *testing.T) {
 	if res.Management {
 		t.Fatal("Management flag of new reservation block must be False")
 	}
+
 	if res.Facility != nil {
 		t.Fatalf("Facility of new reservation should be nil")
 	}
 
 	ipList, _, err = c.ProjectIPs.List(projectID)
-	if len(ipList) != 1 {
-		t.Fatalf("There should be only one reservation, was: %s", ipList)
-	}
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(ipList) != 1 {
+		t.Fatalf("There should be only one reservation, was: %s", ipList)
 	}
 
 	sameRes, _, err := c.ProjectIPs.Get(res.ID, nil)
@@ -157,8 +158,7 @@ func TestAccGlobalIPReservation(t *testing.T) {
 			res, sameRes)
 	}
 
-	availableAddresses, _, err := c.ProjectIPs.AvailableAddresses(
-		res.ID, &AvailableRequest{CIDR: 32})
+	availableAddresses, _, err := c.ProjectIPs.AvailableAddresses(res.ID, &AvailableRequest{CIDR: 32})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR allows to use Packngo structs to reserve Global floating IPs (which can be assinged in multiple facilities), not only Public IPs (which can be assigned only in a specific facility).

This is also towards fixing https://github.com/terraform-providers/terraform-provider-packet/issues/91

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/128)
<!-- Reviewable:end -->
