### PR TITLE
Enable go modules

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 pipeline:
   lint:
-    image: golang:1.9
+    image: golang:1.11
     commands:
       - go get -v -u github.com/alecthomas/gometalinter
       - gometalinter --install
@@ -18,11 +18,11 @@ pipeline:
       - if ! $ok; then exit 1; fi
 
   build:
-    image: golang:1.9
+    image: golang:1.11
     commands:
       - go build -i -v ./...
 
   test:
-    image: golang:1.9
+    image: golang:1.11
     commands:
       - go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/packethost/packngo
+
+require (
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
+	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503 h1:5SvYFrOM3W8Mexn9/oA44Ji7vhXAZQ9hiP+1Q/DMrWg=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This is in preparation to switching [Terraform Packet provider](https://github.com/terraform-providers/terraform-provider-packet) to go modules (see https://github.com/terraform-providers/terraform-provider-packet/issues/94).

Enabling go modules throughout the dependency tree of the provider will make the switch and future upgrades easier.

This PR is a result of the following commands (in a clean Go `1.11.5` environment):

```sh
go mod init
go get ./...
go mod tidy
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packngo/130)
<!-- Reviewable:end -->
