### PR TITLE
Expose *FromURL for metadata to allow mocking for tests

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -12,10 +12,10 @@ import (
 const BaseURL = "https://metadata.packet.net"
 
 func GetMetadata() (*CurrentDevice, error) {
-	return getMetadataFromURL(BaseURL)
+	return GetMetadataFromURL(BaseURL)
 }
 
-func getMetadataFromURL(baseURL string) (*CurrentDevice, error) {
+func GetMetadataFromURL(baseURL string) (*CurrentDevice, error) {
 	res, err := http.Get(baseURL + "/metadata")
 	if err != nil {
 		return nil, err
@@ -44,10 +44,10 @@ func getMetadataFromURL(baseURL string) (*CurrentDevice, error) {
 }
 
 func GetUserData() ([]byte, error) {
-	return getUserDataFromURL(BaseURL)
+	return GetUserDataFromURL(BaseURL)
 }
 
-func getUserDataFromURL(baseURL string) ([]byte, error) {
+func GetUserDataFromURL(baseURL string) ([]byte, error) {
 	res, err := http.Get(baseURL + "/userdata")
 	if err != nil {
 		return nil, err

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -28,7 +28,7 @@ func Test_Deserialization(t *testing.T) {
 		w.Write(b)
 	})
 
-	device, err := getMetadataFromURL(baseURL)
+	device, err := GetMetadataFromURL(baseURL)
 	assert.Nil(t, err)
 	assert.NotNil(t, device)
 


### PR DESCRIPTION
The `metadata.GetMetadata()` and `metadata.GetUserdata()` calls are public, but the `getMetadataFromURL()` and `getUserdataFromURL()` are not. This makes it difficult to stub them out without doing something really messy like overriding DNS.

The `*FromURL()` functions should be exposed, just like we do for `packngo.NewClientWithBaseURL(url)`.