### PR TITLE
Fix linter, add Makefile with docs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,23 +6,14 @@ pipeline:
   lint:
     image: golang:1.11
     commands:
-      - go get -v -u github.com/alecthomas/gometalinter
-      - gometalinter --install
-      - go get -v -t ./...
-      - |
-        gometalinter --disable=gas ./... || :
-      - |
-        gometalinter --disable-all --enable=gas ./... || :
-      - |
-        gofmt -d . | (! grep '.') || ok=false
-      - if ! $ok; then exit 1; fi
+      - make lint BUILD=local
 
   build:
     image: golang:1.11
     commands:
-      - go build -i -v ./...
+      - make build BUILD=local
 
   test:
     image: golang:1.11
     commands:
-      - go test ./...
+      - make test BUILD=local

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+IMG ?= golang:1.11
+
+# enable go modules, disabled CGO
+GOENV ?= GO111MODULE=on CGO_ENABLED=0
+export GO111MODULE=on
+export CGO_ENABLED=0
+
+# we build in a docker image, unless we are set to BUILD=local
+GO ?= docker run --rm -v $(PWD):/app -w /app $(IMG) env $(GOENV)
+ifeq ($(BUILD),local)
+GO = 
+endif
+
+
+build:
+	$(GO) go build -i -v ./...
+
+golangci-lint:
+ifeq (, $(shell which golangci-lint))
+	$(GO) go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+endif
+
+golint:
+ifeq (, $(shell which golint))
+	$(GO) go get -u golang.org/x/lint/golint
+endif
+
+lint: golint golangci-lint
+	$(GO) golangci-lint run --disable-all --enable=golint ./...
+	$(GO) go vet ./...
+	$(GO) gofmt -d .
+
+test:
+	$(GO) test ./...
+

--- a/README.md
+++ b/README.md
@@ -125,3 +125,21 @@ Committing
 ----------
 
 Before committing, it's a good idea to run `gofmt -w *.go`. ([gofmt](https://golang.org/cmd/gofmt/))
+
+## Building and Testing
+
+The [Makefile](./Makefile) contains the targets to build, lint and test:
+
+```sh
+make build
+make lint
+make test
+```
+
+These normally will be run in a docker image of golang. To run locally, just run with `BUILD=local`:
+
+```sh
+make build BUILD=local
+make lint BUILD=local
+make test BUILD=local
+```

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -25,7 +25,7 @@ func TestAccCheckCapacity(t *testing.T) {
 
 	for _, s := range cap.Servers {
 		if !s.Available {
-			t.Fatal(fmt.Errorf("Capacity of %d severs should have been available.", input.Servers[0].Quantity))
+			t.Fatal(fmt.Errorf("capacity of %d servers should have been available", input.Servers[0].Quantity))
 			break
 		}
 	}
@@ -50,7 +50,7 @@ func TestAccCheckCapacity(t *testing.T) {
 
 	for _, s := range cap.Servers {
 		if s.Available {
-			t.Fatal(fmt.Errorf("Capacity of %d severs should not have been available.", input.Servers[0].Quantity))
+			t.Fatal(fmt.Errorf("capacity of %d servers should not have been available", input.Servers[0].Quantity))
 			break
 		}
 	}

--- a/connect.go
+++ b/connect.go
@@ -53,11 +53,11 @@ type connectsRoot struct {
 func (c *ConnectServiceOp) List(projectID string, listOpt *ListOptions) (connects []Connect, resp *Response, err error) {
 	params := createListOptionsURL(listOpt)
 
-	project_param := fmt.Sprintf("project_id=%s", projectID)
+	projectParam := fmt.Sprintf("project_id=%s", projectID)
 	if params == "" {
-		params = project_param
+		params = projectParam
 	} else {
-		params = fmt.Sprintf("%s&%s", params, project_param)
+		params = fmt.Sprintf("%s&%s", params, projectParam)
 	}
 	path := fmt.Sprintf("%s/?%s", connectBasePath, params)
 
@@ -123,11 +123,11 @@ func (c *ConnectServiceOp) Create(createRequest *ConnectCreateRequest) (*Connect
 
 func (c *ConnectServiceOp) Get(connectID, projectID string, getOpt *GetOptions) (*Connect, *Response, error) {
 	params := createGetOptionsURL(getOpt)
-	project_param := fmt.Sprintf("project_id=%s", projectID)
+	projectParam := fmt.Sprintf("project_id=%s", projectID)
 	if params == "" {
-		params = project_param
+		params = projectParam
 	} else {
-		params = fmt.Sprintf("%s&%s", params, project_param)
+		params = fmt.Sprintf("%s&%s", params, projectParam)
 	}
 	path := fmt.Sprintf("%s/%s?%s", connectBasePath, connectID, params)
 	connect := new(Connect)

--- a/ip.go
+++ b/ip.go
@@ -22,7 +22,7 @@ type ProjectIPService interface {
 	AvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error)
 }
 
-type IpAddressCommon struct {
+type IpAddressCommon struct { //nolint:golint
 	ID            string `json:"id"`
 	Address       string `json:"address"`
 	Gateway       string `json:"gateway"`

--- a/volumes.go
+++ b/volumes.go
@@ -222,17 +222,17 @@ func (v *VolumeAttachmentServiceOp) Delete(attachmentID string) (*Response, erro
 }
 
 // Lock sets a volume to "locked"
-func (s *VolumeServiceOp) Lock(id string) (*Response, error) {
+func (v *VolumeServiceOp) Lock(id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", volumeBasePath, id)
 	action := lockType{Locked: true}
 
-	return s.client.DoRequest("PATCH", path, action, nil)
+	return v.client.DoRequest("PATCH", path, action, nil)
 }
 
 // Unlock sets a volume to "unlocked"
-func (s *VolumeServiceOp) Unlock(id string) (*Response, error) {
+func (v *VolumeServiceOp) Unlock(id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", volumeBasePath, id)
 	action := lockType{Locked: false}
 
-	return s.client.DoRequest("PATCH", path, action, nil)
+	return v.client.DoRequest("PATCH", path, action, nil)
 }


### PR DESCRIPTION
As discussed in #148, this fixes the linter. It does several things:

* fix the linter by replacing the deprecated (and unsupported) metalinter with golanglint
* create a makefile with option to run all of the steps in a docker image (so no local install required) or locally
* change the `.drone.yml` to just call the makefile, running locally