### PR TITLE
Add Owner link to SSHKey resource

### DIFF
--- a/sshkeys.go
+++ b/sshkeys.go
@@ -28,7 +28,7 @@ type SSHKey struct {
 	FingerPrint string `json:"fingerprint"`
 	Created     string `json:"created_at"`
 	Updated     string `json:"updated_at"`
-	User        User   `json:"user,omitempty"`
+	Owner       Href
 	URL         string `json:"href,omitempty"`
 }
 

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -52,6 +52,9 @@ func TestAccSSHKeyList(t *testing.T) {
 
 	for _, k := range keys {
 		if k.ID == key.ID {
+			if len(k.Owner.Href) == 0 {
+				t.Error("new Key doesn't have owner URL set")
+			}
 			return
 		}
 	}
@@ -78,6 +81,9 @@ func TestAccSSHKeyProjectList(t *testing.T) {
 
 	for _, k := range keys {
 		if k.ID == key.ID {
+			if len(k.Owner.Href) == 0 {
+				t.Error("new Key doesn't have owner URL set")
+			}
 			return
 		}
 	}
@@ -97,6 +103,9 @@ func TestAccSSHKeyGet(t *testing.T) {
 		got, _, err := c.SSHKeys.Get(k.ID, nil)
 		if err != nil {
 			t.Fatalf("failed to retrieve created key")
+		}
+		if len(got.Owner.Href) == 0 {
+			t.Error("new Key doesn't have owner URL set")
 		}
 
 		if !reflect.DeepEqual(k, got) {
@@ -120,6 +129,9 @@ func TestAccSSHKeyCreate(t *testing.T) {
 	key, _, err := c.SSHKeys.Create(&req)
 	if err != nil {
 		t.Fatalf("errored posting key: %v", err)
+	}
+	if len(key.Owner.Href) == 0 {
+		t.Error("new Key doesn't have owner URL set")
 	}
 
 	if key.Label != req.Label {


### PR DESCRIPTION
This adds Owner link to the SSHKey resoruce struct. In order to be able to better read Project keys in the terraform provider. Fixes #155 