### PR TITLE
clarify parameter

### DIFF
--- a/bgp_configs.go
+++ b/bgp_configs.go
@@ -7,7 +7,7 @@ var bgpConfigBasePath = "/bgp-config"
 // BGPConfigService interface defines available BGP config methods
 type BGPConfigService interface {
 	Get(projectID string, getOpt *GetOptions) (*BGPConfig, *Response, error)
-	Create(string, CreateBGPConfigRequest) (*Response, error)
+	Create(projectID string, request CreateBGPConfigRequest) (*Response, error)
 	// Delete(configID string) (resp *Response, err error) TODO: Not in Packet API
 }
 


### PR DESCRIPTION
Simple change. The first parameter for `BGPConfigService` is of type `string`, but doesn't say what it is for. This clarifies it by naming it. It would have saved me a few minutes today; no reason not to be super-user-friendly and save it for others. :-)