### PR TITLE
Add Support for CustomData to IP Reservations

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -23,22 +23,23 @@ type ProjectIPService interface {
 }
 
 type IpAddressCommon struct { //nolint:golint
-	ID            string   `json:"id"`
-	Address       string   `json:"address"`
-	Gateway       string   `json:"gateway"`
-	Network       string   `json:"network"`
-	AddressFamily int      `json:"address_family"`
-	Netmask       string   `json:"netmask"`
-	Public        bool     `json:"public"`
-	CIDR          int      `json:"cidr"`
-	Created       string   `json:"created_at,omitempty"`
-	Updated       string   `json:"updated_at,omitempty"`
-	Href          string   `json:"href"`
-	Management    bool     `json:"management"`
-	Manageable    bool     `json:"manageable"`
-	Project       Href     `json:"project"`
-	Global        *bool    `json:"global_ip"`
-	Tags          []string `json:"tags,omitempty"`
+	ID            string                 `json:"id"`
+	Address       string                 `json:"address"`
+	Gateway       string                 `json:"gateway"`
+	Network       string                 `json:"network"`
+	AddressFamily int                    `json:"address_family"`
+	Netmask       string                 `json:"netmask"`
+	Public        bool                   `json:"public"`
+	CIDR          int                    `json:"cidr"`
+	Created       string                 `json:"created_at,omitempty"`
+	Updated       string                 `json:"updated_at,omitempty"`
+	Href          string                 `json:"href"`
+	Management    bool                   `json:"management"`
+	Manageable    bool                   `json:"manageable"`
+	Project       Href                   `json:"project"`
+	Global        *bool                  `json:"global_ip"`
+	Tags          []string               `json:"tags,omitempty"`
+	CustomData    map[string]interface{} `json:"customdata,omitempty"`
 }
 
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).
@@ -70,11 +71,12 @@ type IPAddressAssignment struct {
 
 // IPReservationRequest represents the body of a reservation request.
 type IPReservationRequest struct {
-	Type        string   `json:"type"`
-	Quantity    int      `json:"quantity"`
-	Description string   `json:"details,omitempty"`
-	Facility    *string  `json:"facility,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
+	Type        string                 `json:"type"`
+	Quantity    int                    `json:"quantity"`
+	Description string                 `json:"details,omitempty"`
+	Facility    *string                `json:"facility,omitempty"`
+	Tags        []string               `json:"tags,omitempty"`
+	CustomData  map[string]interface{} `json:"customdata,omitempty"`
 }
 
 // AddressStruct is a helper type for request/response with dict like {"address": ... }

--- a/ip_test.go
+++ b/ip_test.go
@@ -2,6 +2,7 @@ package packngo
 
 import (
 	"path"
+	"reflect"
 	"testing"
 )
 
@@ -25,10 +26,13 @@ func TestAccPublicIPReservation(t *testing.T) {
 		t.Fatalf("There should be no reservations a new project, existing list: %s", ipList)
 	}
 
+	customData := map[string]interface{}{"custom1": "data", "custom2": map[string]interface{}{"nested": "data"}}
+
 	req := IPReservationRequest{
-		Type:     "public_ipv4",
-		Quantity: quantity,
-		Facility: &testFac,
+		Type:       "public_ipv4",
+		Quantity:   quantity,
+		Facility:   &testFac,
+		CustomData: customData,
 	}
 
 	res, _, err := c.ProjectIPs.Request(projectID, &req)
@@ -54,6 +58,11 @@ func TestAccPublicIPReservation(t *testing.T) {
 		t.Fatalf(
 			"Facility of new reservation should be %s, was %s", testFac,
 			res.Facility.Code)
+	}
+
+	if !reflect.DeepEqual(customData, res.CustomData) {
+		t.Fatalf(
+			"CustomData of new reservation should be %+v, was %+v", customData, res.CustomData)
 	}
 
 	ipList, _, err = c.ProjectIPs.List(projectID)


### PR DESCRIPTION
Adds support for CustomData (free form JSON data) to IP Address Reservations, as available in the Packet API.