### PR TITLE
Add ability to list IP reservations by device

### DIFF
--- a/devices_test.go
+++ b/devices_test.go
@@ -404,6 +404,22 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// check that the IP assignment is retrievable via the IP-by-device endpoint
+	assignments, _, err := c.DeviceIPs.List(d.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var matchedAssignment bool
+	for _, ip := range assignments {
+		if ip.String() == assignment.String() {
+			matchedAssignment = true
+			break
+		}
+	}
+	if !matchedAssignment {
+		t.Fatal("newly assigned IP not found")
+	}
+
 	// If the Quantity in the IPReservationRequest is >1, this test won't work.
 	// The assignment CIDR would then have to be extracted from the reserved
 	// block.
@@ -527,7 +543,7 @@ func TestAccDeviceAttachVolumeForceDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-    _, err = c.Devices.Delete(d.ID, true)
+	_, err = c.Devices.Delete(d.ID, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ip.go
+++ b/ip.go
@@ -11,6 +11,7 @@ type DeviceIPService interface {
 	Assign(deviceID string, assignRequest *AddressStruct) (*IPAddressAssignment, *Response, error)
 	Unassign(assignmentID string) (*Response, error)
 	Get(assignmentID string, getOpt *GetOptions) (*IPAddressAssignment, *Response, error)
+	List(deviceID string, listOpt *ListOptions) ([]IPAddressAssignment, *Response, error)
 }
 
 // ProjectIPService handles reservation of IP address blocks for a project.
@@ -134,6 +135,27 @@ func (i *DeviceIPServiceOp) Get(assignmentID string, getOpt *GetOptions) (*IPAdd
 	}
 
 	return ipa, resp, err
+}
+
+// List list all of the IP address assignments on a device
+func (i *DeviceIPServiceOp) List(deviceID string, listOpt *ListOptions) ([]IPAddressAssignment, *Response, error) {
+	params := createListOptionsURL(listOpt)
+
+	path := fmt.Sprintf("%s/%s%s?%s", deviceBasePath, deviceID, ipBasePath, params)
+
+	//ipList represents collection of IP Address reservations
+	type ipList struct {
+		IPs []IPAddressAssignment `json:"ip_addresses,omitempty"`
+	}
+
+	ips := new(ipList)
+
+	resp, err := i.client.DoRequest("GET", path, nil, ips)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ips.IPs, resp, err
 }
 
 // ProjectIPServiceOp is interface for IP assignment methods.

--- a/ports.go
+++ b/ports.go
@@ -161,9 +161,9 @@ func (i *DevicePortServiceOp) PortToLayerThree(portID string) (*Port, *Response,
 
 	req := BackToL3Request{
 		RequestIPs: []AddressRequest{
-			AddressRequest{AddressFamily: 4, Public: true},
-			AddressRequest{AddressFamily: 4, Public: false},
-			AddressRequest{AddressFamily: 6, Public: true},
+			{AddressFamily: 4, Public: true},
+			{AddressFamily: 4, Public: false},
+			{AddressFamily: 6, Public: true},
 		},
 	}
 


### PR DESCRIPTION
We already have the ability to request an IP address assignment, get an assignment, and delete one. We didn't have the ability to list by device, which is a specific IP endpoint [here](https://www.packet.com/developers/api/ipaddresses/#retrieve-all-ip-assignments). This adds it.

Only one file was changed. However, running `gofmt` automatically reformatted a few other files that (apparently) needed `gofmt` fixing.