### PR TITLE
Add fixed constants for usage with IP address types

### DIFF
--- a/devices_test.go
+++ b/devices_test.go
@@ -377,7 +377,7 @@ func TestAccDeviceAssignIP(t *testing.T) {
 	}
 
 	req := IPReservationRequest{
-		Type:        "public_ipv4",
+		Type:        PublicIPv4,
 		Quantity:    1,
 		Description: "packngo test",
 		Facility:    &fac,
@@ -527,7 +527,7 @@ func TestAccDeviceAttachVolumeForceDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-    _, err = c.Devices.Delete(d.ID, true)
+	_, err = c.Devices.Delete(d.ID, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ip.go
+++ b/ip.go
@@ -6,6 +6,21 @@ import (
 
 const ipBasePath = "/ips"
 
+const (
+	// PublicIPv4 fixed string representation of public ipv4
+	PublicIPv4 = "public_ipv4"
+	// PrivateIPv4 fixed string representation of private ipv4
+	PrivateIPv4 = "private_ipv4"
+	// GlobalIPv4 fixed string representation of global ipv4
+	GlobalIPv4 = "global_ipv4"
+	// PublicIPv6 fixed string representation of public ipv6
+	PublicIPv6 = "public_ipv6"
+	// PrivateIPv6 fixed string representation of private ipv6
+	PrivateIPv6 = "private_ipv6"
+	// GlobalIPv6 fixed string representation of global ipv6
+	GlobalIPv6 = "global_ipv6"
+)
+
 // DeviceIPService handles assignment of addresses from reserved blocks to instances in a project.
 type DeviceIPService interface {
 	Assign(deviceID string, assignRequest *AddressStruct) (*IPAddressAssignment, *Response, error)

--- a/ip_test.go
+++ b/ip_test.go
@@ -29,7 +29,7 @@ func TestAccPublicIPReservation(t *testing.T) {
 	customData := map[string]interface{}{"custom1": "data", "custom2": map[string]interface{}{"nested": "data"}}
 
 	req := IPReservationRequest{
-		Type:       "public_ipv4",
+		Type:     PublicIPv4,
 		Quantity:   quantity,
 		Facility:   &testFac,
 		CustomData: customData,
@@ -128,7 +128,7 @@ func TestAccGlobalIPReservation(t *testing.T) {
 
 	description := "packngo test"
 	req := IPReservationRequest{
-		Type:        "global_ipv4",
+		Type:        GlobalIPv4,
 		Quantity:    quantity,
 		Description: description,
 	}


### PR DESCRIPTION
Just to make life easier (and less likely to have errors) when using fixed strings of only a few valid values.