### PR TITLE
add support for IP FailOnApprovalRequired

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -93,6 +93,9 @@ type IPReservationRequest struct {
 	Facility    *string                `json:"facility,omitempty"`
 	Tags        []string               `json:"tags,omitempty"`
 	CustomData  map[string]interface{} `json:"customdata,omitempty"`
+	// FailOnApprovalRequired if the IP request cannot be approved automatically, rather than sending to
+	// the longer Packet approval process, fail immediately with a 422 error
+	FailOnApprovalRequired bool `json:"fail_on_approval_required,omitempty"`
 }
 
 // AddressStruct is a helper type for request/response with dict like {"address": ... }


### PR DESCRIPTION
Two days ago, the Packet API added support for `fail_on_approval_required` for IP Reservation Requests. 

Normally, when you request an IP, one of three things happen:

* fail: malformed request or bad token
* success: you are within your IP quota and there is space
* approval required: you have exceeded your quota or there isn't IP space available

In the latter case, you have to reach out to support to see what is happening with the ticket.

"Fail on approval required", or by its short-name "fail-fast", is an option you can pass that causes it _not_ to go into the support queue. If the system cannot allocate an IP immediately, it will return a 422 failure, enabling a lot of automation.

This PR adds support for the option on IP Reservation Request.

In the next week or two, more options will be added.