### PR TITLE
add missing Device.Description field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ minimize them and move towards a 1.0 release.
 - Add ListProject function to the SSHKeys interface
 - Operations for switching between Network Modes, aka "L2 support"
   Support for Organization, Payment Method and Billing address resources
+- Device.Description has been added to packngo (it was missing)
 
 ### Fixed
 - User.Emails json tag is fixed to match api response

--- a/devices.go
+++ b/devices.go
@@ -33,6 +33,7 @@ type Device struct {
 	ID                  string                 `json:"id"`
 	Href                string                 `json:"href,omitempty"`
 	Hostname            string                 `json:"hostname,omitempty"`
+	Description         *string                `json:"description,omitempty"`
 	State               string                 `json:"state,omitempty"`
 	Created             string                 `json:"created_at,omitempty"`
 	Updated             string                 `json:"updated_at,omitempty"`
@@ -49,6 +50,7 @@ type Device struct {
 	ProvisionEvents     []*Event               `json:"provisioning_events,omitempty"`
 	ProvisionPer        float32                `json:"provisioning_percentage,omitempty"`
 	UserData            string                 `json:"userdata,omitempty"`
+	User                string                 `json:"user,omitempty"`
 	RootPassword        string                 `json:"root_password,omitempty"`
 	IPXEScriptURL       string                 `json:"ipxe_script_url,omitempty"`
 	AlwaysPXE           bool                   `json:"always_pxe,omitempty"`
@@ -223,6 +225,7 @@ type DeviceCreateRequest struct {
 	UserData              string     `json:"userdata"`
 	Storage               *CPR       `json:"storage,omitempty"`
 	Tags                  []string   `json:"tags"`
+	Description           string     `json:"description,omitempty"`
 	IPXEScriptURL         string     `json:"ipxe_script_url,omitempty"`
 	PublicIPv4SubnetSize  int        `json:"public_ipv4_subnet_size,omitempty"`
 	AlwaysPXE             bool       `json:"always_pxe,omitempty"`

--- a/devices_test.go
+++ b/devices_test.go
@@ -107,6 +107,7 @@ func TestAccDeviceBasic(t *testing.T) {
 		OS:           "ubuntu_16_04",
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
+		Description:  "test",
 	}
 
 	d, _, err := c.Devices.Create(&cr)
@@ -137,6 +138,12 @@ func TestAccDeviceBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if d.User != "root" {
+		t.Fatal("user should be 'root'")
+	}
+	if d.Description == nil || *d.Description != cr.Description {
+		t.Fatal("description is empty or non-existent")
+	}
 	if len(d.RootPassword) == 0 {
 		t.Fatal("root_password is empty or non-existent")
 	}


### PR DESCRIPTION
I noticed that `Description` is available for `Update` calls on the `Device` object, but it is not available from `DeviceService.Get`.

It should be present according to the OpenAPI spec.

I've added that field and noted this in the changelog (which is overdue for reflecting v0.2.0)