### PR TITLE
add ListOptions to project ips list

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -32,7 +32,7 @@ type DeviceIPService interface {
 // ProjectIPService handles reservation of IP address blocks for a project.
 type ProjectIPService interface {
 	Get(reservationID string, getOpt *GetOptions) (*IPAddressReservation, *Response, error)
-	List(projectID string) ([]IPAddressReservation, *Response, error)
+	List(projectID string, listOpt *ListOptions) ([]IPAddressReservation, *Response, error)
 	Request(projectID string, ipReservationReq *IPReservationRequest) (*IPAddressReservation, *Response, error)
 	Remove(ipReservationID string) (*Response, error)
 	AvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error)
@@ -61,12 +61,12 @@ type IpAddressCommon struct { //nolint:golint
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).
 type IPAddressReservation struct {
 	IpAddressCommon
-	Assignments []Href    `json:"assignments"`
-	Facility    *Facility `json:"facility,omitempty"`
-	Available   string    `json:"available"`
-	Addon       bool      `json:"addon"`
-	Bill        bool      `json:"bill"`
-	Description *string   `json:"details"`
+	Assignments []*IPAddressAssignment `json:"assignments"`
+	Facility    *Facility              `json:"facility,omitempty"`
+	Available   string                 `json:"available"`
+	Addon       bool                   `json:"addon"`
+	Bill        bool                   `json:"bill"`
+	Description *string                `json:"details"`
 }
 
 // AvailableResponse is a type for listing of available addresses from a reserved block.
@@ -198,8 +198,10 @@ func (i *ProjectIPServiceOp) Get(reservationID string, getOpt *GetOptions) (*IPA
 }
 
 // List provides a list of IP resevations for a single project.
-func (i *ProjectIPServiceOp) List(projectID string) ([]IPAddressReservation, *Response, error) {
-	path := fmt.Sprintf("%s/%s%s", projectBasePath, projectID, ipBasePath)
+func (i *ProjectIPServiceOp) List(projectID string, listOpt *ListOptions) ([]IPAddressReservation, *Response, error) {
+	params := createListOptionsURL(listOpt)
+
+	path := fmt.Sprintf("%s/%s%s?%s", projectBasePath, projectID, ipBasePath, params)
 	reservations := new(struct {
 		Reservations []IPAddressReservation `json:"ip_addresses"`
 	})

--- a/ip_test.go
+++ b/ip_test.go
@@ -18,7 +18,7 @@ func TestAccPublicIPReservation(t *testing.T) {
 	testFac := testFacility()
 	quantity := 2
 
-	ipList, _, err := c.ProjectIPs.List(projectID)
+	ipList, _, err := c.ProjectIPs.List(projectID, &ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestAccPublicIPReservation(t *testing.T) {
 			"CustomData of new reservation should be %+v, was %+v", customData, res.CustomData)
 	}
 
-	ipList, _, err = c.ProjectIPs.List(projectID)
+	ipList, _, err = c.ProjectIPs.List(projectID, &ListOptions{})
 	if len(ipList) != 1 {
 		t.Fatalf("There should be only one reservation, was: %s", ipList)
 	}
@@ -118,7 +118,7 @@ func TestAccGlobalIPReservation(t *testing.T) {
 
 	quantity := 1
 
-	ipList, _, err := c.ProjectIPs.List(projectID)
+	ipList, _, err := c.ProjectIPs.List(projectID, &ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestAccGlobalIPReservation(t *testing.T) {
 		t.Fatalf("Facility of new reservation should be nil")
 	}
 
-	ipList, _, err = c.ProjectIPs.List(projectID)
+	ipList, _, err = c.ProjectIPs.List(projectID, &ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`ProjectIPService.List()` should accept a `ListOptions`, per the underlying API.

