### PR TITLE
simplify GetNetworkType logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	$(GO) go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+	$(GO) go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
 endif
 
 golint:

--- a/devices.go
+++ b/devices.go
@@ -181,13 +181,17 @@ func (d *Device) HasManagementIPs() bool {
 	return false
 }
 
-func (d *Device) GetNetworkType() (string, error) {
+// GetNetworkType returns a composite network type identification for a device
+// based on the plan, network_type, and IP management state of the device.
+// GetNetworkType provides the same composite state rendered in the Packet
+// Portal for a given device.
+func (d *Device) GetNetworkType() string {
 	if d.Plan != nil {
 		if d.Plan.Slug == "baremetal_0" || d.Plan.Slug == "baremetal_1" {
-			return NetworkTypeL3, nil
+			return NetworkTypeL3
 		}
 		if d.Plan.Slug == "baremetal_1e" {
-			return NetworkTypeHybrid, nil
+			return NetworkTypeHybrid
 		}
 	}
 
@@ -197,13 +201,13 @@ func (d *Device) GetNetworkType() (string, error) {
 	if bonds.allBonded() {
 		if phys.allBonded() {
 			if !d.HasManagementIPs() {
-				return NetworkTypeL2Bonded, nil
+				return NetworkTypeL2Bonded
 			}
-			return NetworkTypeL3, nil
+			return NetworkTypeL3
 		}
-		return NetworkTypeHybrid, nil
+		return NetworkTypeHybrid
 	}
-	return NetworkTypeL2Individual, nil
+	return NetworkTypeL2Individual
 }
 
 type IPAddressCreateRequest struct {

--- a/devices_test.go
+++ b/devices_test.go
@@ -186,9 +186,9 @@ func TestAccDeviceBasic(t *testing.T) {
 	if len(d.SwitchUUID) == 0 {
 		t.Fatal("Device should have switch UUID")
 	}
-	_, err = d.GetNetworkType()
-	if err != nil {
-		t.Fatal(err)
+	networkType := d.GetNetworkType()
+	if networkType != NetworkTypeL3 {
+		t.Fatal("network_type should be 'layer3'")
 	}
 
 	if d.User != "root" {
@@ -1077,9 +1077,9 @@ func TestAccDeviceIPAddresses(t *testing.T) {
 	dID := d.ID
 
 	d = waitDeviceActive(t, c, dID)
-	_, err = d.GetNetworkType()
-	if err != nil {
-		t.Fatal(err)
+	networkType := d.GetNetworkType()
+	if networkType != NetworkTypeL3 {
+		t.Fatal("network_type should be 'layer3'")
 	}
 
 	if len(d.RootPassword) == 0 {
@@ -1153,13 +1153,12 @@ func TestDevice_GetNetworkType(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		fields  fields
-		want    string
-		wantErr bool
+		name   string
+		fields fields
+		want   string
 	}{
 		{
-			name: "GetNetworkType_bm0_provisiong", // t1.small.x86
+			name: "GetNetworkType_bm0_provisioning", // t1.small.x86
 			fields: fields{Plan: &Plan{Slug: "baremetal_0"},
 				NetworkPorts: []Port{{
 					Type: "NetworkBondPort",
@@ -1182,8 +1181,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					},
 				}},
 			},
-			want:    NetworkTypeL3,
-			wantErr: false,
+			want: NetworkTypeL3,
 		},
 		{
 			name: "GetNetworkType_bm0_ready", // t1.small.x86 post-provision
@@ -1210,8 +1208,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					},
 				}},
 			},
-			want:    NetworkTypeL3,
-			wantErr: false,
+			want: NetworkTypeL3,
 		},
 		{
 			name: "GetNetworkType_bm1", // c1.small.x86
@@ -1236,8 +1233,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 						Bonded: true,
 					},
 				}}},
-			want:    NetworkTypeL3,
-			wantErr: false,
+			want: NetworkTypeL3,
 		},
 		{
 			name: "GetNetworkType_bm1e_provisioning", // x1.small.x86
@@ -1263,8 +1259,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 						Bonded: true,
 					},
 				}}},
-			want:    NetworkTypeHybrid,
-			wantErr: false,
+			want: NetworkTypeHybrid,
 		},
 		{
 			name: "GetNetworkType_bm1e_provisioning", // x1.small.x86
@@ -1289,15 +1284,13 @@ func TestDevice_GetNetworkType(t *testing.T) {
 						Bonded: false,
 					},
 				}}},
-			want:    NetworkTypeHybrid,
-			wantErr: false,
+			want: NetworkTypeHybrid,
 		},
 		{
 			// a configuration that should not be observed, one nic, no bonds.
-			name:    "GetNetworkType_OneNic_NoBonds",
-			fields:  fields{NetworkPorts: []Port{{Bond: nil}}},
-			want:    NetworkTypeL2Individual,
-			wantErr: false,
+			name:   "GetNetworkType_OneNic_NoBonds",
+			fields: fields{NetworkPorts: []Port{{Bond: nil}}},
+			want:   NetworkTypeL2Individual,
 		},
 		{
 			name: "GetNetworkType_TwoNics_NoBonds", // c3-medium l2-individual
@@ -1321,8 +1314,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Bonded: false,
 				},
 			}}},
-			want:    NetworkTypeL2Individual,
-			wantErr: false,
+			want: NetworkTypeL2Individual,
 		},
 		{
 			name: "GetNetworkType_FourNics_NotBonded", // n2-xlarge l2-individual
@@ -1365,8 +1357,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Bonded: false,
 				},
 			}}},
-			want:    NetworkTypeL2Individual,
-			wantErr: false,
+			want: NetworkTypeL2Individual,
 		},
 		{
 			name: "GetNetworkType_TwoNics_Bonded_WithManagement", // c3-medium l3
@@ -1392,8 +1383,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 						Bonded: true,
 					},
 				}}},
-			want:    NetworkTypeL3,
-			wantErr: false,
+			want: NetworkTypeL3,
 		},
 		{
 			name: "GetNetworkType_FourNics_Bonded_WithManagement", // n2-xlarge l3
@@ -1439,8 +1429,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					},
 				},
 				}},
-			want:    NetworkTypeL3,
-			wantErr: false,
+			want: NetworkTypeL3,
 		},
 
 		{
@@ -1487,8 +1476,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					},
 				},
 				}},
-			want:    NetworkTypeL2Bonded,
-			wantErr: false,
+			want: NetworkTypeL2Bonded,
 		},
 		{
 			name: "GetNetworkType_TwoNics_Bonded", // c3-medium l2-bonded
@@ -1512,8 +1500,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Bonded: true,
 				},
 			}}},
-			want:    NetworkTypeL2Bonded,
-			wantErr: false,
+			want: NetworkTypeL2Bonded,
 		},
 		{
 			name: "GetNetworkType_TwoNics_OneBonded", // c3-medium hybrid
@@ -1537,8 +1524,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Bonded: false,
 				},
 			}}},
-			want:    NetworkTypeHybrid,
-			wantErr: false,
+			want: NetworkTypeHybrid,
 		},
 		{
 			name: "GetNetworkType_FourNics_Bonded", // n2-xlarge hybrid
@@ -1583,8 +1569,7 @@ func TestDevice_GetNetworkType(t *testing.T) {
 						Bonded: false,
 					},
 				}}},
-			want:    NetworkTypeHybrid,
-			wantErr: false,
+			want: NetworkTypeHybrid,
 		},
 	}
 	for _, tt := range tests {
@@ -1594,11 +1579,8 @@ func TestDevice_GetNetworkType(t *testing.T) {
 				Plan:         tt.fields.Plan,
 				NetworkPorts: tt.fields.NetworkPorts,
 			}
-			got, err := d.GetNetworkType()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Device.GetNetworkType() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := d.GetNetworkType()
+
 			if got != tt.want {
 				t.Errorf("Device.GetNetworkType() = %v, want %v", got, tt.want)
 			}

--- a/ports.go
+++ b/ports.go
@@ -188,7 +188,7 @@ func (i *DevicePortServiceOp) DeviceNetworkType(deviceID string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	return d.GetNetworkType()
+	return d.GetNetworkType(), nil
 }
 
 func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) error {
@@ -325,10 +325,7 @@ func (i *DevicePortServiceOp) DeviceToNetworkType(deviceID string, targetType st
 		return nil, err
 	}
 
-	curType, err := d.GetNetworkType()
-	if err != nil {
-		return nil, err
-	}
+	curType := d.GetNetworkType()
 
 	if curType == targetType {
 		return nil, fmt.Errorf("Device already is in state %s", targetType)
@@ -353,10 +350,7 @@ func (i *DevicePortServiceOp) DeviceToNetworkType(deviceID string, targetType st
 		return nil, err
 	}
 
-	finalType, err := d.GetNetworkType()
-	if err != nil {
-		return nil, err
-	}
+	finalType := d.GetNetworkType()
 
 	if finalType != targetType {
 		return nil, fmt.Errorf(

--- a/ports.go
+++ b/ports.go
@@ -22,8 +22,8 @@ type DevicePortService interface {
 	PortToLayerTwo(string, string) (*Port, *Response, error)
 	PortToLayerThree(string, string) (*Port, *Response, error)
 	GetPortByName(string, string) (*Port, error)
-	GetOddEthPorts(*Device) (ports, error)
-	GetAllEthPorts(*Device) (ports, error)
+	GetOddEthPorts(*Device) (map[string]*Port, error)
+	GetAllEthPorts(*Device) (map[string]*Port, error)
 	ConvertDevice(*Device, string) error
 }
 
@@ -194,7 +194,7 @@ func (i *DevicePortServiceOp) DeviceNetworkType(deviceID string) (string, error)
 	return d.GetNetworkType(), nil
 }
 
-func (i *DevicePortServiceOp) GetAllEthPorts(d *Device) (ports, error) {
+func (i *DevicePortServiceOp) GetAllEthPorts(d *Device) (map[string]*Port, error) {
 	d, _, err := i.client.Devices.Get(d.ID, nil)
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (i *DevicePortServiceOp) GetAllEthPorts(d *Device) (ports, error) {
 	return d.GetPhysicalPorts(), nil
 }
 
-func (i *DevicePortServiceOp) GetOddEthPorts(d *Device) (ports, error) {
+func (i *DevicePortServiceOp) GetOddEthPorts(d *Device) (map[string]*Port, error) {
 	d, _, err := i.client.Devices.Get(d.ID, nil)
 	if err != nil {
 		return nil, err

--- a/ports.go
+++ b/ports.go
@@ -233,6 +233,10 @@ func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) e
 			if err != nil {
 				return err
 			}
+			_, _, err = i.client.DevicePorts.Disbond(p, false)
+			if err != nil {
+				return err
+			}
 		}
 		for _, p := range ethPorts {
 			_, _, err := i.client.DevicePorts.Disbond(p, false)

--- a/ports.go
+++ b/ports.go
@@ -161,7 +161,7 @@ func (i *DevicePortServiceOp) PortToLayerThree(deviceID, portName string) (*Port
 	if err != nil {
 		return nil, nil, err
 	}
-	if p.NetworkType == "layer3" {
+	if p.NetworkType == NetworkTypeL3 {
 		return p, nil, nil
 	}
 	path := fmt.Sprintf("%s/%s/convert/layer-3", portBasePath, p.ID)
@@ -195,7 +195,7 @@ func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) e
 	bondPorts := d.GetBondPorts()
 	ethPorts := d.GetPhysicalPorts()
 
-	if targetType == "layer3" {
+	if targetType == NetworkTypeL3 {
 		for _, p := range ethPorts {
 			_, _, err := i.client.DevicePorts.Bond(p, false)
 			if err != nil {
@@ -209,7 +209,7 @@ func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) e
 			}
 		}
 	}
-	if targetType == "hybrid" {
+	if targetType == NetworkTypeHybrid {
 		for _, p := range d.GetPortsInBond("bond1") {
 			_, _, err := i.client.DevicePorts.Disbond(p, false)
 			if err != nil {
@@ -225,7 +225,7 @@ func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) e
 			return err
 		}
 	}
-	if targetType == "layer2-individual" {
+	if targetType == NetworkTypeL2Individual {
 		for _, p := range bondPorts {
 			_, _, err := i.client.DevicePorts.PortToLayerTwo(d.ID, p.Name)
 			if err != nil {
@@ -239,7 +239,7 @@ func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) e
 			}
 		}
 	}
-	if targetType == "layer2-bonded" {
+	if targetType == NetworkTypeL2Bonded {
 		for _, p := range bondPorts {
 			_, _, err := i.client.DevicePorts.PortToLayerTwo(d.ID, p.Name)
 			if err != nil {
@@ -263,7 +263,7 @@ func (i *DevicePortServiceOp) Convert1BondDevice(d *Device, targetType string) e
 	}
 	bond0ports := d.GetPortsInBond("bond0")
 
-	if targetType == "layer3" {
+	if targetType == NetworkTypeL3 {
 		for _, p := range bond0ports {
 			_, _, err = i.client.DevicePorts.Bond(p, false)
 			if err != nil {
@@ -275,7 +275,7 @@ func (i *DevicePortServiceOp) Convert1BondDevice(d *Device, targetType string) e
 			return err
 		}
 	}
-	if targetType == "hybrid" {
+	if targetType == NetworkTypeHybrid {
 		_, _, err = i.client.DevicePorts.Bond(bond0, false)
 		if err != nil {
 			return err
@@ -293,7 +293,7 @@ func (i *DevicePortServiceOp) Convert1BondDevice(d *Device, targetType string) e
 			return err
 		}
 	}
-	if targetType == "layer2-individual" {
+	if targetType == NetworkTypeL2Individual {
 		bond0, _, err = i.client.DevicePorts.PortToLayerTwo(d.ID, "bond0")
 		if err != nil {
 			return err
@@ -303,7 +303,7 @@ func (i *DevicePortServiceOp) Convert1BondDevice(d *Device, targetType string) e
 			return err
 		}
 	}
-	if targetType == "layer2-bonded" {
+	if targetType == NetworkTypeL2Bonded {
 		for _, p := range bond0ports {
 			_, _, err = i.client.DevicePorts.Bond(p, false)
 			if err != nil {

--- a/ports.go
+++ b/ports.go
@@ -218,7 +218,16 @@ func (i *DevicePortServiceOp) Convert2BondDevice(d *Device, targetType string) e
 				return err
 			}
 		}
-		_, _, err := i.client.DevicePorts.PortToLayerThree(d.ID, "bond0")
+		bond0, err := d.GetPortByName("bond0")
+		if err != nil {
+			return err
+		}
+		_, _, err = i.client.DevicePorts.Bond(bond0, false)
+		if err != nil {
+			return err
+		}
+
+		_, _, err = i.client.DevicePorts.PortToLayerThree(d.ID, "bond0")
 		if err != nil {
 			return err
 		}

--- a/ports_test.go
+++ b/ports_test.go
@@ -490,9 +490,9 @@ func TestAccPortNetworkStateTransitions(t *testing.T) {
 
 	d = waitDeviceActive(t, c, deviceID)
 
-	networkType, err := d.GetNetworkType()
-	if err != nil {
-		t.Fatal(err)
+	networkType := d.GetNetworkType()
+	if networkType != NetworkTypeL3 {
+		t.Fatal("network_type should be 'layer3'")
 	}
 
 	if networkType != NetworkTypeL2Bonded {

--- a/ports_test.go
+++ b/ports_test.go
@@ -64,7 +64,7 @@ func TestAccPort1E(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if nType != "hybrid" {
+	if nType != NetworkTypeHybrid {
 		t.Fatal("New 1E device should be in Hybrid Network Type")
 	}
 
@@ -193,11 +193,11 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 		t.Fatal(err)
 	}
 
-	if nType != "layer3" {
+	if nType != NetworkTypeL3 {
 		t.Fatalf("New %s device should be in network type L3", plan)
 	}
 
-	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, "hybrid")
+	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, NetworkTypeHybrid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 		t.Fatal(err)
 	}
 
-	if nType != "hybrid" {
+	if nType != NetworkTypeHybrid {
 		t.Fatal("the device should now be in network type L2 Bonded")
 	}
 
@@ -255,7 +255,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 		t.Fatal("No vlans should be attached to the port at this time")
 	}
 
-	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, "layer3")
+	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, NetworkTypeL3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 		t.Fatal(err)
 	}
 
-	if nType != "layer3" {
+	if nType != NetworkTypeL3 {
 		t.Fatal("the device should now be back in network type L3")
 	}
 
@@ -349,11 +349,11 @@ func testL2L3Convert(t *testing.T, plan string) {
 		t.Fatal(err)
 	}
 
-	if nType != "layer3" {
+	if nType != NetworkTypeL3 {
 		t.Fatalf("New %s device should be in network type L3", plan)
 	}
 
-	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, "layer2-bonded")
+	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, NetworkTypeL2Bonded)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 		t.Fatal(err)
 	}
 
-	if nType != "layer2-bonded" {
+	if nType != NetworkTypeL2Bonded {
 		t.Fatal("the device should now be in network type L2 Bonded")
 	}
 
@@ -412,7 +412,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 		t.Fatal("No vlans should be attached to the port at this time")
 	}
 
-	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, "layer3")
+	d, err = c.DevicePorts.DeviceToNetworkType(d.ID, NetworkTypeL3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 		t.Fatal(err)
 	}
 
-	if nType != "layer3" {
+	if nType != NetworkTypeL3 {
 		t.Fatal("the device now should be back in network type L3")
 	}
 
@@ -456,11 +456,11 @@ defer stopRecord()
 	}
 
 	log.Println(d)
-	deviceToNetworkType(t, c, deviceID, "layer3")
-	deviceToNetworkType(t, c, deviceID, "hybrid")
-	deviceToNetworkType(t, c, deviceID, "layer3")
-	deviceToNetworkType(t, c, deviceID, "layer2-individual")
-	deviceToNetworkType(t, c, deviceID, "layer3")
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL3)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeHybrid)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL3)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Individual)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL3)
 
 }
 */
@@ -495,25 +495,25 @@ func TestAccPortNetworkStateTransitions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if networkType != "layer2-bonded" {
-		deviceToNetworkType(t, c, deviceID, "layer2-bonded")
+	if networkType != NetworkTypeL2Bonded {
+		deviceToNetworkType(t, c, deviceID, NetworkTypeL2Bonded)
 	}
 
-	deviceToNetworkType(t, c, deviceID, "layer2-individual")
-	deviceToNetworkType(t, c, deviceID, "layer3")
-	deviceToNetworkType(t, c, deviceID, "hybrid")
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Individual)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL3)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeHybrid)
 
-	deviceToNetworkType(t, c, deviceID, "layer2-bonded")
-	deviceToNetworkType(t, c, deviceID, "layer3")
-	deviceToNetworkType(t, c, deviceID, "layer2-bonded")
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Bonded)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL3)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Bonded)
 
-	deviceToNetworkType(t, c, deviceID, "hybrid")
-	deviceToNetworkType(t, c, deviceID, "layer2-individual")
-	deviceToNetworkType(t, c, deviceID, "hybrid")
+	deviceToNetworkType(t, c, deviceID, NetworkTypeHybrid)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Individual)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeHybrid)
 
-	deviceToNetworkType(t, c, deviceID, "layer3")
-	deviceToNetworkType(t, c, deviceID, "layer2-individual")
-	deviceToNetworkType(t, c, deviceID, "layer2-bonded")
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL3)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Individual)
+	deviceToNetworkType(t, c, deviceID, NetworkTypeL2Bonded)
 }
 
 func TestAccPortNativeVlan(t *testing.T) {
@@ -541,7 +541,7 @@ func TestAccPortNativeVlan(t *testing.T) {
 	d = waitDeviceActive(t, c, deviceID)
 	defer deleteDevice(t, c, d.ID, false)
 
-	deviceToNetworkType(t, c, deviceID, "hybrid")
+	deviceToNetworkType(t, c, deviceID, NetworkTypeHybrid)
 
 	vncr := VirtualNetworkCreateRequest{
 		ProjectID: projectID,

--- a/ports_test.go
+++ b/ports_test.go
@@ -15,7 +15,7 @@ func TestAccPort1E(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	t.Parallel()
 
-	// MARK_1
+	// MARK__1
 
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()


### PR DESCRIPTION
Simplify the logic of `device.GetNetworkType()` based on the logic used in the Packet user portal website.

With this refactor:
* `GetNetworkType` can not return an error
  * Is this ok? Are we worried about unexpected API responses not bubbling up because of the new logical conditions?
* The reported network type will match the Packet UI
  * This adds extra conditions for `c1.small.x86`, `t1.small.x86`, and `x1.small.x86`.

TODO:
* [x] Add tests
  * [x] baremetal_0 in hybrid in layer3 (includes bond0:layer2-bonded fixtures based on captured API data)
  * [x] baremetal_1
  * [x] baremetal_1e in hybrid
  * [x] c3.medium in hybrid, l2-individual, l2-bonded, l3
  * [x] n2.x-large in hybrid, l2-individual, l2-bonded, l3
* [x] Verify that the [existing GetBondPorts / GetPhysicalPorts](https://github.com/packethost/packngo/pull/185/files#diff-1a60e1c4cc0c82b6f9d8eef9bcb80257L118-L138) provides the same result as the `port.name` filtering ES6 code (`networkPorts` and `bondPorts` below)

Questions:
* Is appears that the bonded port returned by the API provides the network-type that we are computing. Why do we need to compute it? (the Web UI is performing the same computation)
  The multiple bond devices may each be in a different network_type, which is the definition of `hybrid` mode.

---

Based on this:
```es6
export const getNetworkingType = (device) => {
  const bondPorts = device.network_ports.filter(port => /bond*/.test(port.name)),
    networkPorts = device.network_ports.filter(port => /eth*/.test(port.name)),
    ipAddresses = device.ip_addresses,
    bondPortsEnabled = bondPorts.length ? bondPorts.every(bondPort => bondPort.data.bonded) : false,
    hasManagementIps = ipAddresses.some(ip => ip.management);
  if (device.plan.slug === 'baremetal_0' || device.plan.slug === 'baremetal_1') { return NETWORK_TYPES.LAYER_3; }
  if (device.plan.slug === 'baremetal_1e') { return NETWORK_TYPES.HYBRID; }
  if (bondPortsEnabled) {
    if (networkPorts.every(port => port.data.bonded)) {
      if (!hasManagementIps) {
        return NETWORK_TYPES.LAYER_2_BONDED;
      }
    } else {
      return NETWORK_TYPES.HYBRID;
    }
  } else {
    return NETWORK_TYPES.LAYER_2_INDIVIDUAL;
  }
  return NETWORK_TYPES.LAYER_3;
};
```

