### PR TITLE
honor client.UserAgent when making requests

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -242,7 +242,7 @@ func (c *Client) NewRequest(method, path string, body interface{}) (*retryableht
 
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
-	req.Header.Add("User-Agent", userAgent)
+	req.Header.Add("User-Agent", c.UserAgent)
 	return req, nil
 }
 


### PR DESCRIPTION
client.UserAgent is ignored when making HTTP requests.

This PR corrects the UserAgent used in requests.