### PR TITLE
docs: describe APIKey fields and APIKeyServiceOp methods

### DIFF
--- a/apikeys.go
+++ b/apikeys.go
@@ -24,21 +24,45 @@ type apiKeyRoot struct {
 }
 
 type APIKey struct {
-	ID          string   `json:"id"`
-	Description string   `json:"description"`
-	Token       string   `json:"token"`
-	ReadOnly    bool     `json:"read_only"`
-	Created     string   `json:"created_at"`
-	Updated     string   `json:"updated_at"`
-	User        *User    `json:"user"`
-	Project     *Project `json:"project"`
+	// ID is the UUIDv4 representing an API key in API requests and responses.
+	ID string `json:"id"`
+
+	// Description is any text description of the key. This can be used to
+	// describe the purpose of the key.
+	Description string `json:"description"`
+
+	// Token is a sensitive credential that can be used as a `Client.APIKey` to
+	// access Packet resources.
+	Token string `json:"token"`
+
+	// ReadOnly keys can not create new resources.
+	ReadOnly bool `json:"read_only"`
+
+	// Created is the creation date of the API key.
+	Created string `json:"created_at"`
+
+	// Updated is the last-update date of the API key.
+	Updated string `json:"updated_at"`
+
+	// User will be non-nil when getting or listing an User API key.
+	User *User `json:"user"`
+
+	// Project will be non-nil when getting or listing a Project API key
+	Project *Project `json:"project"`
 }
 
-// APIKeyCreateRequest type used to create an api key
+// APIKeyCreateRequest type used to create an api key.
 type APIKeyCreateRequest struct {
+	// Description is any text description of the key. This can be used to
+	// describe the purpose of the key.
 	Description string `json:"description"`
-	ReadOnly    bool   `json:"read_only"`
-	ProjectID   string `json:"-"`
+
+	// ReadOnly keys can not create new resources.
+	ReadOnly bool `json:"read_only"`
+
+	// ProjectID when non-empty will result in the creation of a Project API
+	// key.
+	ProjectID string `json:"-"`
 }
 
 func (s APIKeyCreateRequest) String() string {
@@ -63,18 +87,29 @@ func (s *APIKeyServiceOp) list(url string, lopts *ListOptions) ([]APIKey, *Respo
 	return root.APIKeys, resp, err
 }
 
-// ProjectList lists api keys of a project
+// ProjectList lists the API keys associated with a project having `projectID`
+// match `Project.ID`.
 func (s *APIKeyServiceOp) ProjectList(projectID string, lopts *ListOptions) ([]APIKey, *Response, error) {
 	return s.list(fmt.Sprintf(apiKeyProjectBasePath, projectID), lopts)
-
 }
 
-// UserList returns a user's api keys
+// UserList returns the API keys for the User associated with the
+// `Client.APIKey`.
+//
+// When `Client.APIKey` is a Project API key, this method will return an access
+// denied error.
 func (s *APIKeyServiceOp) UserList(lopts *ListOptions) ([]APIKey, *Response, error) {
 	return s.list(apiKeyUserBasePath, lopts)
 }
 
-// ProjectGet returns an api key by id
+// ProjectGet returns the Project API key with the given `APIKey.ID`.
+//
+// In other methods, it is typical for a Response to be returned, which could
+// include a StatusCode of `http.StatusNotFound` (404 error) when the resource
+// was not found. The Packet API does not expose a get by ID endpoint for
+// APIKeys.  That is why in this method, all API keys are listed and compared
+// for a match. Therefor, the Response is not returned and a custom error will
+// be returned when the key is not found.
 func (s *APIKeyServiceOp) ProjectGet(projectID, apiKeyID string, getOpt *GetOptions) (*APIKey, error) {
 	var lopts *ListOptions
 	if getOpt != nil {
@@ -92,7 +127,14 @@ func (s *APIKeyServiceOp) ProjectGet(projectID, apiKeyID string, getOpt *GetOpti
 	return nil, fmt.Errorf("Project (%s) API key %s not found", projectID, apiKeyID)
 }
 
-// UserGet returns a project api key by id
+// UserGet returns the User API key with the given `APIKey.ID`.
+//
+// In other methods, it is typical for a Response to be returned, which could
+// include a StatusCode of `http.StatusNotFound` (404 error) when the resource
+// was not found. The Packet API does not expose a get by ID endpoint for
+// APIKeys.  That is why in this method, all API keys are listed and compared
+// for a match. Therefor, the Response is not returned and a custom error will
+// be returned when the key is not found.
 func (s *APIKeyServiceOp) UserGet(apiKeyID string, getOpt *GetOptions) (*APIKey, error) {
 	var lopts *ListOptions
 	if getOpt != nil {
@@ -110,7 +152,11 @@ func (s *APIKeyServiceOp) UserGet(apiKeyID string, getOpt *GetOptions) (*APIKey,
 	return nil, fmt.Errorf("User API key %s not found", apiKeyID)
 }
 
-// Create creates a new api key
+// Create creates a new API key.
+//
+// The API key can be either an User API key or a Project API key, determined by
+// the value (or emptiness) of `APIKeyCreateRequest.ProjectID`. Either `User` or
+// `Project` will be non-nil in the `APIKey` depending on this factor.
 func (s *APIKeyServiceOp) Create(createRequest *APIKeyCreateRequest) (*APIKey, *Response, error) {
 	path := apiKeyUserBasePath
 	if createRequest.ProjectID != "" {
@@ -126,7 +172,11 @@ func (s *APIKeyServiceOp) Create(createRequest *APIKeyCreateRequest) (*APIKey, *
 	return apiKey, resp, err
 }
 
-// Delete deletes an api key
+// Delete deletes an API key by `APIKey.ID`
+//
+// The API key can be either an User API key or a Project API key.
+//
+// Project API keys can not be used to delete themselves.
 func (s *APIKeyServiceOp) Delete(apiKeyID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", apiKeyUserBasePath, apiKeyID)
 	return s.client.DoRequest("DELETE", path, nil, nil)


### PR DESCRIPTION
I tripped over the missing docs in both this project and https://www.packet.com/developers/api/.

I'm adding these docs as a result of thinking that Project API Key creation was not a feature of packngo.  It is.

I used curl calls to discover how the API can and can not be used. I'll be relying on this information in https://github.com/displague/packet-actions-example.

Signed-off-by: Marques Johansson <marques@packet.com>