### PR TITLE
Equinix Metal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Documentation at <https://godoc.org/github.com/packethost/packngo> will be
 generated from these comments.
 
 The documentation provided for packngo fields and functions should be at or
-better than the quality provided at <https://www.packet.com/developers/api/>.
+better than the quality provided at <https://metal.equinix.com/developers/api/>.
 When the API documentation provides a lengthy description, a linking to the
 related API documentation will benefit users.
 
@@ -63,7 +63,7 @@ make test BUILD=local
 
 ### Acceptance Tests
 
-If you want to run tests against the actual Packet API, you must set the
+If you want to run tests against the actual Equinix Metal API, you must set the
 environment variable `PACKET_TEST_ACTUAL_API` to a non-empty string and set
 `PACKNGO_TEST_RECORDER` to `disabled`. The device tests wait for the device
 creation, so it's best to run a few in parallel.
@@ -87,7 +87,7 @@ By default, `go test ./...` will skip most of the tests unless
 `PACKNGO_TEST_ACTUAL_API` is non-empty.
 
 With the `PACKNGO_TEST_ACTUAL_API` environment variable set, tests will be run
-against the Packet API, creating real infrastructure and incurring costs.
+against the Equinix Metal API, creating real infrastructure and incurring costs.
 
 The `PACKNGO_TEST_RECORDER` variable can be used to record and playback API
 responses to test code changes without the delay and costs of making actual API
@@ -98,7 +98,7 @@ the future once fixtures are available for all tests.
 When `PACKNGO_TEST_RECORDER` is set to `play`, tests will playback API responses
 from recorded HTTP response fixtures. This is idea for refactoring and making
 changes to request and response handling without introducing changes to the data
-sent or received by the Packet API.
+sent or received by the Equinix Metal API.
 
 When adding support for new end-points, recorded test sessions should be added.
 Record the HTTP interactions to fixtures by setting the environment variable

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,11 +1,11 @@
 # Owners
 
-This project is governed by [Packet] and benefits from a community of users that
-collaborate and contribute to its use in Go powered projects, such as th [Packet
+This project is governed by [Equinix Metal] and benefits from a community of users that
+collaborate and contribute to its use in Go powered projects, such as th [Equinix Metal
 Terraform provider], [Docker machine driver], Kubernetes drivers for [CSI] and [CCM],
-the [Packet CLI], and others.
+the [Equinix Metal CLI], and others.
 
-Members of the Packet Github organization will strive to triage issues in a
+Members of the Equinix Metal Github organization will strive to triage issues in a
 timely manner, see [SUPPORT.md] for details.
 
 See the [packethost/standards glossary] for more details about this file.
@@ -14,12 +14,12 @@ See the [packethost/standards glossary] for more details about this file.
 
 Maintainers of this repository are defined within the [CODEOWNERS] file.
 
-[Packet]: https://packet.com
-[Packet Terraform provider]: https://github.com/packethost/terraform-provider-packet
+[Equinix Metal]: https://metal.equinix.com
+[Equinix Metal Terraform provider]: https://github.com/packethost/terraform-provider-packet
 [Docker machine driver]: https://github.com/packethost/docker-machine-driver-packet
 [CSI]: https://github.com/packethost/csi-packet
 [CCM]: https://github.com/packethost/packet-ccm
-[Packet CLI]: https://github.com/packethost/packet-cli
+[Equinix Metal CLI]: https://github.com/packethost/packet-cli
 [SUPPORT.md]: SUPPORT.md
 [packethost/standards
 glossary]: https://github.com/packethost/standards/blob/master/glossary.md#ownersmd

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Release](https://img.shields.io/github/v/release/packethost/packngo)](https://github.com/packethost/packngo/releases/latest)
 [![GoDoc](https://godoc.org/github.com/packethost/packngo?status.svg)](https://godoc.org/github.com/packethost/packngo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/packethost/packngo)](https://goreportcard.com/report/github.com/packethost/packngo)
-[![Slack](https://slack.packet.com/badge.svg)](https://slack.packet.com)
-[![Twitter Follow](https://img.shields.io/twitter/follow/packethost.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=packethost)
+[![Slack](https://slack.equinixmetal.com/badge.svg)](https://slack.equinixmetal.com/)
+[![Twitter Follow](https://img.shields.io/twitter/follow/equinixmetal.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=equinixmetal)
 
-A Golang client for the Equinix Metal API. This client previously acted as the Equinix Metal API go-client.
+A Golang client for the Equinix Metal API. ([Packet is now Equinix Metal](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Slack](https://slack.packet.com/badge.svg)](https://slack.packet.com)
 [![Twitter Follow](https://img.shields.io/twitter/follow/packethost.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=packethost)
 
-A Golang client for the Packet API.
+A Golang client for the Equinix Metal API. This client previously acted as the Equinix Metal API go-client.
 
 ## Installation
 
@@ -25,19 +25,19 @@ go get github.com/packethost/packngo@v0.2.0
 
 ## Stability and Compatibility
 
-This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Packet and its community - available to use in production environments.
+This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Equinix Metal and its community - available to use in production environments.
 
 Packngo is currently provided with a major version of [v0](https://blog.golang.org/v2-go-modules). We'll try to avoid breaking changes to this library, but they will certainly happen as we work towards a stable v1 library. See [CHANGELOG.md](CHANGELOG.md) for details on the latest additions, removals, fixes, and breaking changes.
 
-While packngo provides an interface to most of the [Packet API](https://www.packet.com/developers/api/), the API is regularly adding new features. To request or contribute support for more API end-points or added fields, [create an issue](https://github.com/packethost/packngo/issues/new).
+While packngo provides an interface to most of the [Equinix Metal API](https://metal.equinix.com/developers/api/), the API is regularly adding new features. To request or contribute support for more API end-points or added fields, [create an issue](https://github.com/packethost/packngo/issues/new).
 
 See [SUPPORT.md](SUPPORT.md) for any other issues.
 
 ## Usage
 
-To authenticate to the Packet API, you must have your API token exported in env var `PACKET_AUTH_TOKEN`.
+To authenticate to the Equinix Metal API, you must have your API token exported in env var `PACKET_AUTH_TOKEN`.
 
-This code snippet initializes Packet API client, and lists your Projects:
+This code snippet initializes Equinix Metal API client, and lists your Projects:
 
 ```go
 package main
@@ -67,16 +67,16 @@ func main() {
 
 This library is used by the official [terraform-provider-packet](https://github.com/terraform-providers/terraform-provider-packet).
 
-You can also learn a lot from the `*_test.go` sources. Almost all out tests touch the Packet API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
+You can also learn a lot from the `*_test.go` sources. Almost all out tests touch the Equinix Metal API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
 
 <details>
 <summary>Linked Resources</summary>
 
 ### Linked resources in Get\* and List\* functions
 
-The Packet API includes references to related entities for a wide selection of resource types, indicated by `href` fields. The Packet API allows for these entities to be included in the API response, saving the user from making more round-trip API requests. This is useful for linked resources, e.g members of a project, devices in a project. Similarly, by excluding entities that are included by default, you can reduce the API response time and payload size.
+The Equinix Metal API includes references to related entities for a wide selection of resource types, indicated by `href` fields. The Equinix Metal API allows for these entities to be included in the API response, saving the user from making more round-trip API requests. This is useful for linked resources, e.g members of a project, devices in a project. Similarly, by excluding entities that are included by default, you can reduce the API response time and payload size.
 
-Control of this behavior is provided through [common attributes](https://www.packet.com/developers/api/common-parameters/) that can be used to toggle, by field name, which referenced resources will be included as values in API responses. The API exposes this feature through `?include=` and `?exclude=` query parameters which accept a comma-separated list of field names. These field names can be dotted to reference nested entities.
+Control of this behavior is provided through [common attributes](https://metal.equinix.com/developers/api/common-parameters/) that can be used to toggle, by field name, which referenced resources will be included as values in API responses. The API exposes this feature through `?include=` and `?exclude=` query parameters which accept a comma-separated list of field names. These field names can be dotted to reference nested entities.
 
 Most of the packngo `Get` functions take references to `GetOptions` parameters (or `ListOptions` for `List` functions). These types include an `Include` and `Exclude` slice that will be converted to query parameters upon request.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,6 +12,6 @@ guaranteed. Issues  will be addressed based on priorities that may or may not
 be reflected in Github or issue comments.
 
 For other forms of support, including our Slack community, visit
-<https://www.packet.com/about/contact/>.
+<https://metal.equinix.com/about/contact/>.
 
 [open a GitHub Issue]: https://github.com/packethost/packngo/issues/new

--- a/apikeys.go
+++ b/apikeys.go
@@ -32,7 +32,7 @@ type APIKey struct {
 	Description string `json:"description"`
 
 	// Token is a sensitive credential that can be used as a `Client.APIKey` to
-	// access Packet resources.
+	// access Equinix Metal resources.
 	Token string `json:"token"`
 
 	// ReadOnly keys can not create new resources.
@@ -106,7 +106,7 @@ func (s *APIKeyServiceOp) UserList(lopts *ListOptions) ([]APIKey, *Response, err
 //
 // In other methods, it is typical for a Response to be returned, which could
 // include a StatusCode of `http.StatusNotFound` (404 error) when the resource
-// was not found. The Packet API does not expose a get by ID endpoint for
+// was not found. The Equinix Metal API does not expose a get by ID endpoint for
 // APIKeys.  That is why in this method, all API keys are listed and compared
 // for a match. Therefor, the Response is not returned and a custom error will
 // be returned when the key is not found.
@@ -131,7 +131,7 @@ func (s *APIKeyServiceOp) ProjectGet(projectID, apiKeyID string, getOpt *GetOpti
 //
 // In other methods, it is typical for a Response to be returned, which could
 // include a StatusCode of `http.StatusNotFound` (404 error) when the resource
-// was not found. The Packet API does not expose a get by ID endpoint for
+// was not found. The Equinix Metal API does not expose a get by ID endpoint for
 // APIKeys.  That is why in this method, all API keys are listed and compared
 // for a match. Therefor, the Response is not returned and a custom error will
 // be returned when the key is not found.

--- a/bgp_configs.go
+++ b/bgp_configs.go
@@ -8,7 +8,7 @@ var bgpConfigBasePath = "/bgp-config"
 type BGPConfigService interface {
 	Get(projectID string, getOpt *GetOptions) (*BGPConfig, *Response, error)
 	Create(projectID string, request CreateBGPConfigRequest) (*Response, error)
-	// Delete(configID string) (resp *Response, err error) TODO: Not in Packet API
+	// Delete(configID string) (resp *Response, err error) TODO: Not in Equinix Metal API
 }
 
 // BGPConfigServiceOp implements BgpConfigService
@@ -24,7 +24,7 @@ type CreateBGPConfigRequest struct {
 	UseCase        string `json:"use_case,omitempty"`
 }
 
-// BGPConfig represents a Packet BGP Config
+// BGPConfig represents an Equinix Metal BGP Config
 type BGPConfig struct {
 	ID             string       `json:"id,omitempty"`
 	Status         string       `json:"status,omitempty"`
@@ -68,7 +68,7 @@ func (s *BGPConfigServiceOp) Get(projectID string, getOpt *GetOptions) (bgpConfi
 	return subset, resp, err
 }
 
-// Delete function TODO: this is not implemented in the Packet API
+// Delete function TODO: this is not implemented in the Equinix Metal API
 // func (s *BGPConfigServiceOp) Delete(configID string) (resp *Response, err error) {
 // 	path := fmt.Sprintf("%ss/%s", bgpConfigBasePath, configID)
 

--- a/bgp_sessions.go
+++ b/bgp_sessions.go
@@ -22,7 +22,7 @@ type BGPSessionServiceOp struct {
 	client *Client
 }
 
-// BGPSession represents a Packet BGP Session
+// BGPSession represents an Equinix Metal BGP Session
 type BGPSession struct {
 	ID            string   `json:"id,omitempty"`
 	Status        string   `json:"status,omitempty"`

--- a/devices.go
+++ b/devices.go
@@ -28,7 +28,7 @@ type devicesRoot struct {
 	Meta    meta     `json:"meta"`
 }
 
-// Device represents a Packet device from API
+// Device represents an Equinix Metal device from API
 type Device struct {
 	ID                  string                 `json:"id"`
 	Href                string                 `json:"href,omitempty"`
@@ -214,7 +214,7 @@ type CPR struct {
 	} `json:"filesystems"`
 }
 
-// DeviceCreateRequest type used to create a Packet device
+// DeviceCreateRequest type used to create an Equinix Metal device
 type DeviceCreateRequest struct {
 	Hostname              string     `json:"hostname"`
 	Plan                  string     `json:"plan"`
@@ -248,7 +248,7 @@ type DeviceCreateRequest struct {
 	IPAddresses    []IPAddressCreateRequest `json:"ip_addresses,omitempty"`
 }
 
-// DeviceUpdateRequest type used to update a Packet device
+// DeviceUpdateRequest type used to update an Equinix Metal device
 type DeviceUpdateRequest struct {
 	Hostname      *string   `json:"hostname,omitempty"`
 	Description   *string   `json:"description,omitempty"`

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,3 @@
+// Package packngo implements the Equinix Metal API
+// documented at https://metal.equinix.com/developers/api.
+package packngo

--- a/examples/otp.go
+++ b/examples/otp.go
@@ -10,7 +10,7 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func GetPacketOtpSms(c *packngo.Client) (string, error) {
+func GetOtpSms(c *packngo.Client) (string, error) {
 	_, err := c.TwoFactorAuth.ReceiveSms()
 	if err != nil {
 		return "", err
@@ -25,7 +25,7 @@ func GetPacketOtpSms(c *packngo.Client) (string, error) {
 	return otp[:len(otp)-1], nil
 }
 
-func SeedPacketOtpApp(c *packngo.Client) (string, error) {
+func SeedOtpApp(c *packngo.Client) (string, error) {
 	otpUri, _, err := c.TwoFactorAuth.SeedApp()
 	if err != nil {
 		return "", err
@@ -39,7 +39,7 @@ func SeedPacketOtpApp(c *packngo.Client) (string, error) {
 	log.Println("Secret for 2FA App:", q["secret"][0])
 
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter Packet 2FA App code: ")
+	fmt.Print("Enter Equinix Metal 2FA App code: ")
 	otp, err := reader.ReadString('\n')
 	if err != nil {
 		return "", err
@@ -63,7 +63,7 @@ func TestSMSEnable() {
 		log.Fatal(err)
 	}
 
-	otp, err := GetPacketOtpSms(c)
+	otp, err := GetOtpSms(c)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestSMSEnable() {
 	}
 	log.Println("SMS enabled")
 
-	otp, err = GetPacketOtpSms(c)
+	otp, err = GetOtpSms(c)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestAppEnable() {
 		log.Fatal(err)
 	}
 
-	otp, err := SeedPacketOtpApp(c)
+	otp, err := SeedOtpApp(c)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/facilities.go
+++ b/facilities.go
@@ -13,7 +13,7 @@ type facilityRoot struct {
 	Facilities []Facility `json:"facilities"`
 }
 
-// Facility represents a Packet facility
+// Facility represents an Equinix Metal facility
 type Facility struct {
 	ID       string   `json:"id"`
 	Name     string   `json:"name,omitempty"`

--- a/ip.go
+++ b/ip.go
@@ -94,7 +94,7 @@ type IPReservationRequest struct {
 	Tags        []string               `json:"tags,omitempty"`
 	CustomData  map[string]interface{} `json:"customdata,omitempty"`
 	// FailOnApprovalRequired if the IP request cannot be approved automatically, rather than sending to
-	// the longer Packet approval process, fail immediately with a 422 error
+	// the longer Equinix Metal approval process, fail immediately with a 422 error
 	FailOnApprovalRequired bool `json:"fail_on_approval_required,omitempty"`
 }
 

--- a/metadata/doc.go
+++ b/metadata/doc.go
@@ -1,0 +1,6 @@
+// Package metadata implements the Equinix Metal Metadata API available
+// to Equinix Metal devices at https://metadata.platformequinix.com/metadata.
+//
+// For more information, see
+// https://metal.equinix.com/developers/docs/servers/metadata/
+package metadata

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 )
 
-const BaseURL = "https://metadata.packet.net"
+const BaseURL = "https://metadata.platformequinix.com"
 
 func GetMetadata() (*CurrentDevice, error) {
 	return GetMetadataFromURL(BaseURL)

--- a/operatingsystems.go
+++ b/operatingsystems.go
@@ -11,7 +11,7 @@ type osRoot struct {
 	OperatingSystems []OS `json:"operating_systems"`
 }
 
-// OS represents a Packet operating system
+// OS represents an Equinix Metal operating system
 type OS struct {
 	Name            string   `json:"name"`
 	Slug            string   `json:"slug"`

--- a/organizations.go
+++ b/organizations.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-// API documentation https://www.packet.net/developers/api/organizations/
+// API documentation https://metal.equinix.com/developers/api/organizations/
 const organizationBasePath = "/organizations"
 
 // OrganizationService interface defines available organization methods
@@ -21,7 +21,7 @@ type organizationsRoot struct {
 	Meta          meta           `json:"meta"`
 }
 
-// Organization represents a Packet organization
+// Organization represents an Equinix Metal organization
 type Organization struct {
 	ID           string    `json:"id"`
 	Name         string    `json:"name,omitempty"`
@@ -47,7 +47,7 @@ func (o Organization) String() string {
 	return Stringify(o)
 }
 
-// OrganizationCreateRequest type used to create a Packet organization
+// OrganizationCreateRequest type used to create an Equinix Metal organization
 type OrganizationCreateRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -60,7 +60,7 @@ func (o OrganizationCreateRequest) String() string {
 	return Stringify(o)
 }
 
-// OrganizationUpdateRequest type used to update a Packet organization
+// OrganizationUpdateRequest type used to update an Equinix Metal organization
 type OrganizationUpdateRequest struct {
 	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`

--- a/packngo.go
+++ b/packngo.go
@@ -24,7 +24,7 @@ import (
 const (
 	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
 	libraryVersion    = "0.3.0"
-	baseURL           = "https://api.packet.net/"
+	baseURL           = "https://api.equinix.com/metal/v1/"
 	userAgent         = "packngo/" + libraryVersion
 	mediaType         = "application/json"
 	debugEnvVar       = "PACKNGO_DEBUG"
@@ -36,11 +36,11 @@ const (
 
 var redirectsErrorRe = regexp.MustCompile(`stopped after \d+ redirects\z`)
 
-// GetOptions are options common to Packet API GET requests
+// GetOptions are options common to Equinix Metal API GET requests
 type GetOptions struct {
 	// Includes are a list of fields to expand in the request results.
 	//
-	// For resources that contain collections of other resources, the Packet API
+	// For resources that contain collections of other resources, the Equinix Metal API
 	// will only return the `Href` value of these resources by default. In
 	// nested API Go types, this will result in objects that have zero values in
 	// all fiends except their `Href` field. When an object's associated field
@@ -53,7 +53,7 @@ type GetOptions struct {
 	// Excludes reduce the size of the API response by removing nested objects
 	// that may be returned.
 	//
-	// The default behavior of the Packet API is to "exclude" fields, but some
+	// The default behavior of the Equinix Metal API is to "exclude" fields, but some
 	// API endpoints have an "include" behavior on certain fields. Nested Go
 	// types unmarshalled into an "excluded" field will only have a values in
 	// their `Href` field.
@@ -70,7 +70,7 @@ func (g *GetOptions) GetOptions() *GetOptions {
 	return &getOpts
 }
 
-// ListOptions are options common to Packet API paginated GET requests
+// ListOptions are options common to Equinix Metal API paginated GET requests
 type ListOptions struct {
 	// avoid embedding GetOptions (packngo-breaking-change) for now
 
@@ -279,7 +279,7 @@ type Client struct {
 
 	RateLimit Rate
 
-	// Packet Api Objects
+	// Equinix Metal Api Objects
 	APIKeys                APIKeyService
 	BGPConfig              BGPConfigService
 	BGPSessions            BGPSessionService
@@ -460,7 +460,7 @@ func NewClient() (*Client, error) {
 }
 
 // NewClientWithAuth initializes and returns a Client, use this to get an API Client to operate on
-// N.B.: Packet's API certificate requires Go 1.5+ to successfully parse. If you are using
+// N.B.: Equinix Metal's API certificate requires Go 1.5+ to successfully parse. If you are using
 // an older version of Go, pass in a custom http.Client with a custom TLS configuration
 // that sets "InsecureSkipVerify" to "true"
 func NewClientWithAuth(consumerToken string, apiKey string, httpClient *retryablehttp.Client) *Client {
@@ -468,7 +468,8 @@ func NewClientWithAuth(consumerToken string, apiKey string, httpClient *retryabl
 	return client
 }
 
-func PacketRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+// RetryPolicy determines if the supplied http Response and error can be safely retried
+func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	// do not retry on context.Canceled or context.DeadlineExceeded
 	if ctx.Err() != nil {
 		return false, ctx.Err()
@@ -513,7 +514,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *retry
 		httpClient.RetryWaitMin = time.Second
 		httpClient.RetryWaitMax = 30 * time.Second
 		httpClient.RetryMax = 10
-		httpClient.CheckRetry = PacketRetryPolicy
+		httpClient.CheckRetry = RetryPolicy
 	}
 
 	u, err := url.Parse(apiBaseURL)

--- a/packngo.go
+++ b/packngo.go
@@ -22,12 +22,12 @@ import (
 )
 
 const (
-	packetTokenEnvVar = "PACKET_AUTH_TOKEN"
-	libraryVersion    = "0.3.0"
-	baseURL           = "https://api.equinix.com/metal/v1/"
-	userAgent         = "packngo/" + libraryVersion
-	mediaType         = "application/json"
-	debugEnvVar       = "PACKNGO_DEBUG"
+	authTokenEnvVar = "PACKET_AUTH_TOKEN"
+	libraryVersion  = "0.3.0"
+	baseURL         = "https://api.equinix.com/metal/v1/"
+	userAgent       = "packngo/" + libraryVersion
+	mediaType       = "application/json"
+	debugEnvVar     = "PACKNGO_DEBUG"
 
 	headerRateLimit     = "X-RateLimit-Limit"
 	headerRateRemaining = "X-RateLimit-Remaining"
@@ -450,9 +450,9 @@ func (c *Client) DoRequestWithHeader(method string, headers map[string]string, p
 
 // NewClient initializes and returns a Client
 func NewClient() (*Client, error) {
-	apiToken := os.Getenv(packetTokenEnvVar)
+	apiToken := os.Getenv(authTokenEnvVar)
 	if apiToken == "" {
-		return nil, fmt.Errorf("you must export %s", packetTokenEnvVar)
+		return nil, fmt.Errorf("you must export %s", authTokenEnvVar)
 	}
 	c := NewClientWithAuth("packngo lib", apiToken, nil)
 	return c, nil

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	packetURLEnvVar   = "PACKET_API_URL"
+	apiURLEnvVar      = "PACKET_API_URL"
 	packngoAccTestVar = "PACKNGO_TEST_ACTUAL_API"
 	testProjectPrefix = "PACKNGO_TEST_DELME_2d768716_"
 	testFacilityVar   = "PACKNGO_TEST_FACILITY"
@@ -149,16 +149,16 @@ func testRecordMode() (recorder.Mode, error) {
 
 func setup(t *testing.T) (*Client, func()) {
 	name := t.Name()
-	apiToken := os.Getenv(packetTokenEnvVar)
+	apiToken := os.Getenv(authTokenEnvVar)
 	if apiToken == "" {
-		t.Fatalf("If you want to run packngo test, you must export %s.", packetTokenEnvVar)
+		t.Fatalf("If you want to run packngo test, you must export %s.", authTokenEnvVar)
 	}
 
 	mode, err := testRecordMode()
 	if err != nil {
 		t.Fatal(err)
 	}
-	apiURL := os.Getenv(packetURLEnvVar)
+	apiURL := os.Getenv(apiURLEnvVar)
 	if apiURL == "" {
 		apiURL = baseURL
 	}

--- a/payment_methods.go
+++ b/payment_methods.go
@@ -68,5 +68,4 @@ func (pm PaymentMethodUpdateRequest) String() string {
 
 // PaymentMethodServiceOp implements PaymentMethodService
 type PaymentMethodServiceOp struct {
-	client *Client
 }

--- a/payment_methods.go
+++ b/payment_methods.go
@@ -1,6 +1,6 @@
 package packngo
 
-// API documentation https://www.packet.net/developers/api/paymentmethods/
+// API documentation https://metal.equinix.com/developers/api/paymentmethods/
 const paymentMethodBasePath = "/payment-methods"
 
 // ProjectService interface defines available project methods
@@ -16,7 +16,7 @@ type paymentMethodsRoot struct {
 	PaymentMethods []PaymentMethod `json:"payment_methods"`
 }
 
-// PaymentMethod represents a Packet payment method of an organization
+// PaymentMethod represents an Equinix Metal payment method of an organization
 type PaymentMethod struct {
 	ID             string         `json:"id"`
 	Name           string         `json:"name,omitempty"`
@@ -39,7 +39,7 @@ func (pm PaymentMethod) String() string {
 	return Stringify(pm)
 }
 
-// PaymentMethodCreateRequest type used to create a Packet payment method of an organization
+// PaymentMethodCreateRequest type used to create an Equinix Metal payment method of an organization
 type PaymentMethodCreateRequest struct {
 	Name           string `json:"name"`
 	Nonce          string `json:"nonce"`
@@ -53,7 +53,7 @@ func (pm PaymentMethodCreateRequest) String() string {
 	return Stringify(pm)
 }
 
-// PaymentMethodUpdateRequest type used to update a Packet payment method of an organization
+// PaymentMethodUpdateRequest type used to update an Equinix Metal payment method of an organization
 type PaymentMethodUpdateRequest struct {
 	Name           *string `json:"name,omitempty"`
 	CardholderName *string `json:"cardholder_name,omitempty"`

--- a/plans.go
+++ b/plans.go
@@ -15,7 +15,7 @@ type planRoot struct {
 	Plans []Plan `json:"plans"`
 }
 
-// Plan represents a Packet service plan
+// Plan represents an Equinix Metal service plan
 type Plan struct {
 	ID              string     `json:"id"`
 	Slug            string     `json:"slug,omitempty"`

--- a/projects.go
+++ b/projects.go
@@ -23,7 +23,7 @@ type projectsRoot struct {
 	Meta     meta      `json:"meta"`
 }
 
-// Project represents a Packet project
+// Project represents an Equinix Metal project
 type Project struct {
 	ID              string        `json:"id"`
 	Name            string        `json:"name,omitempty"`
@@ -42,7 +42,7 @@ func (p Project) String() string {
 	return Stringify(p)
 }
 
-// ProjectCreateRequest type used to create a Packet project
+// ProjectCreateRequest type used to create an Equinix Metal project
 type ProjectCreateRequest struct {
 	Name            string `json:"name"`
 	PaymentMethodID string `json:"payment_method_id,omitempty"`
@@ -53,7 +53,7 @@ func (p ProjectCreateRequest) String() string {
 	return Stringify(p)
 }
 
-// ProjectUpdateRequest type used to update a Packet project
+// ProjectUpdateRequest type used to update an Equinix Metal project
 type ProjectUpdateRequest struct {
 	Name            *string `json:"name,omitempty"`
 	PaymentMethodID *string `json:"payment_method_id,omitempty"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -322,7 +322,7 @@ func TestAccProjectListSSHKeys(t *testing.T) {
 	defer teardown()
 
 	key := createKey(t, c, projectID)
-	defer c.SSHKeys.Delete(key.ID)
+	defer deleteSSHKey(t, c, key.ID)
 
 	keys, _, err := c.Projects.ListSSHKeys(projectID, &SearchOptions{Search: key.Label})
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -17,7 +17,7 @@ type usersRoot struct {
 	Meta  meta   `json:"meta"`
 }
 
-// User represents a Packet user
+// User represents an Equinix Metal user
 type User struct {
 	ID                    string  `json:"id"`
 	FirstName             string  `json:"first_name,omitempty"`

--- a/volumes.go
+++ b/volumes.go
@@ -63,7 +63,7 @@ func (v Volume) String() string {
 	return Stringify(v)
 }
 
-// VolumeCreateRequest type used to create a Packet volume
+// VolumeCreateRequest type used to create an Equinix Metal volume
 type VolumeCreateRequest struct {
 	BillingCycle     string            `json:"billing_cycle"`
 	Description      string            `json:"description,omitempty"`
@@ -78,7 +78,7 @@ func (v VolumeCreateRequest) String() string {
 	return Stringify(v)
 }
 
-// VolumeUpdateRequest type used to update a Packet volume
+// VolumeUpdateRequest type used to update an Equinix Metal volume
 type VolumeUpdateRequest struct {
 	Description  *string `json:"description,omitempty"`
 	PlanID       *string `json:"plan_id,omitempty"`
@@ -86,7 +86,7 @@ type VolumeUpdateRequest struct {
 	BillingCycle *string `json:"billing_cycle,omitempty"`
 }
 
-// VolumeAttachment is a type from Packet API
+// VolumeAttachment is a type from Equinix Metal API
 type VolumeAttachment struct {
 	Href   string `json:"href"`
 	ID     string `json:"id"`


### PR DESCRIPTION
[Packet is now Equinix Metal](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/).

Renames all things Packet to Equinix Metal.

* Updates the documentation (Packet -> Equinix Metal) and links to documentation
* Updates the API and Metadata URLs
* **BREAKING CHANGE** Renames packngo.PacketRetryPolicy to packngo.RetryPolicy

These changes will be released, on merge, as v0.4.0 and the changelog will note this breaking change and the change in the URLs (so that users can revise any access policies, if needed).

This **DOES NOT** do the following (which will be introduced later):
* change the name "packngo"
* change references of "github.com/packethost"
* change the `PACKET_AUTH_TOKEN` environment variable