### PR TITLE
[WIP] Remove leading slashes from all the consts for API endpoint URLs

### DIFF
--- a/apikeys.go
+++ b/apikeys.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	apiKeyUserBasePath    = "/user/api-keys"
-	apiKeyProjectBasePath = "/projects/%s/api-keys"
+	apiKeyUserBasePath    = "user/api-keys"
+	apiKeyProjectBasePath = "projects/%s/api-keys"
 )
 
 // APIKeyService interface defines available device methods

--- a/batches.go
+++ b/batches.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const batchBasePath = "/batches"
+const batchBasePath = "batches"
 
 // BatchService interface defines available batch methods
 type BatchService interface {

--- a/bgp_configs.go
+++ b/bgp_configs.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-var bgpConfigBasePath = "/bgp-config"
+var bgpConfigBasePath = "bgp-config"
 
 // BGPConfigService interface defines available BGP config methods
 type BGPConfigService interface {

--- a/bgp_sessions.go
+++ b/bgp_sessions.go
@@ -2,8 +2,8 @@ package packngo
 
 import "fmt"
 
-var bgpSessionBasePath = "/bgp/sessions"
-var bgpNeighborsBasePath = "/bgp/neighbors"
+var bgpSessionBasePath = "bgp/sessions"
+var bgpNeighborsBasePath = "bgp/neighbors"
 
 // BGPSessionService interface defines available BGP session methods
 type BGPSessionService interface {

--- a/capacities.go
+++ b/capacities.go
@@ -1,6 +1,6 @@
 package packngo
 
-const capacityBasePath = "/capacity"
+const capacityBasePath = "capacity"
 
 // CapacityService interface defines available capacity methods
 type CapacityService interface {

--- a/devices.go
+++ b/devices.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const deviceBasePath = "/devices"
+const deviceBasePath = "devices"
 
 // DeviceService interface defines available device methods
 type DeviceService interface {

--- a/email.go
+++ b/email.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-const emailBasePath = "/emails"
+const emailBasePath = "emails"
 
 // EmailRequest type used to add an email address to the current user
 type EmailRequest struct {

--- a/events.go
+++ b/events.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-const eventBasePath = "/events"
+const eventBasePath = "events"
 
 // Event struct
 type Event struct {

--- a/facilities.go
+++ b/facilities.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-const facilityBasePath = "/facilities"
+const facilityBasePath = "facilities"
 
 // FacilityService interface defines available facility methods
 type FacilityService interface {

--- a/hardware_reservations.go
+++ b/hardware_reservations.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-const hardwareReservationBasePath = "/hardware-reservations"
+const hardwareReservationBasePath = "hardware-reservations"
 
 // HardwareReservationService interface defines available hardware reservation functions
 type HardwareReservationService interface {

--- a/ip.go
+++ b/ip.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const ipBasePath = "/ips"
+const ipBasePath = "ips"
 
 const (
 	// PublicIPv4 fixed string representation of public ipv4

--- a/notifications.go
+++ b/notifications.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-const notificationBasePath = "/notifications"
+const notificationBasePath = "notifications"
 
 // Notification struct
 type Notification struct {

--- a/operatingsystems.go
+++ b/operatingsystems.go
@@ -1,6 +1,6 @@
 package packngo
 
-const osBasePath = "/operating-systems"
+const osBasePath = "operating-systems"
 
 // OSService interface defines available operating_systems methods
 type OSService interface {

--- a/organizations.go
+++ b/organizations.go
@@ -3,7 +3,7 @@ package packngo
 import "fmt"
 
 // API documentation https://metal.equinix.com/developers/api/organizations/
-const organizationBasePath = "/organizations"
+const organizationBasePath = "organizations"
 
 // OrganizationService interface defines available organization methods
 type OrganizationService interface {

--- a/payment_methods.go
+++ b/payment_methods.go
@@ -1,7 +1,7 @@
 package packngo
 
 // API documentation https://metal.equinix.com/developers/api/paymentmethods/
-const paymentMethodBasePath = "/payment-methods"
+const paymentMethodBasePath = "payment-methods"
 
 // ProjectService interface defines available project methods
 type PaymentMethodService interface {

--- a/plans.go
+++ b/plans.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const planBasePath = "/plans"
+const planBasePath = "plans"
 
 // PlanService interface defines available plan methods
 type PlanService interface {

--- a/ports.go
+++ b/ports.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const portBasePath = "/ports"
+const portBasePath = "ports"
 
 // DevicePortService handles operations on a port which belongs to a particular device
 type DevicePortService interface {

--- a/projects.go
+++ b/projects.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const projectBasePath = "/projects"
+const projectBasePath = "projects"
 
 // ProjectService interface defines available project methods
 type ProjectService interface {

--- a/spotmarket.go
+++ b/spotmarket.go
@@ -1,6 +1,6 @@
 package packngo
 
-const spotMarketBasePath = "/market/spot/prices"
+const spotMarketBasePath = "market/spot/prices"
 
 // SpotMarketService expooses Spot Market methods
 type SpotMarketService interface {

--- a/spotmarketrequest.go
+++ b/spotmarketrequest.go
@@ -5,7 +5,7 @@ import (
 	"math"
 )
 
-const spotMarketRequestBasePath = "/spot-market-requests"
+const spotMarketRequestBasePath = "spot-market-requests"
 
 type SpotMarketRequestService interface {
 	List(string, *ListOptions) ([]SpotMarketRequest, *Response, error)

--- a/sshkeys.go
+++ b/sshkeys.go
@@ -3,7 +3,7 @@ package packngo
 import "fmt"
 
 const (
-	sshKeyBasePath = "/ssh-keys"
+	sshKeyBasePath = "ssh-keys"
 )
 
 // SSHKeyService interface defines available device methods

--- a/user.go
+++ b/user.go
@@ -2,8 +2,8 @@ package packngo
 
 import "fmt"
 
-const usersBasePath = "/users"
-const userBasePath = "/user"
+const usersBasePath = "users"
+const userBasePath = "user"
 
 // UserService interface defines available user methods
 type UserService interface {

--- a/virtualnetworks.go
+++ b/virtualnetworks.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const virtualNetworkBasePath = "/virtual-networks"
+const virtualNetworkBasePath = "virtual-networks"
 
 // DevicePortService handles operations on a port which belongs to a particular device
 type ProjectVirtualNetworkService interface {

--- a/volumes.go
+++ b/volumes.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	volumeBasePath      = "/storage"
-	attachmentsBasePath = "/attachments"
+	volumeBasePath      = "storage"
+	attachmentsBasePath = "attachments"
 )
 
 // VolumeService interface defines available Volume methods

--- a/vpn.go
+++ b/vpn.go
@@ -2,7 +2,7 @@ package packngo
 
 import "fmt"
 
-const vpnBasePath = "/user/vpn"
+const vpnBasePath = "user/vpn"
 
 // VPNConfig struct
 type VPNConfig struct {


### PR DESCRIPTION
This fixes #198 in a more proper way

This did the trick:
```
 sed -i 's|\(BasePath.* = \"\)/|\1|' *.go
```

