### PR TITLE
tests: use common and modern facilities and plans

### DIFF
--- a/batches_test.go
+++ b/batches_test.go
@@ -16,9 +16,9 @@ func TestAccInstanceBatches(t *testing.T) {
 			{
 				DeviceCreateRequest: DeviceCreateRequest{
 					Hostname:     "test1",
-					Plan:         "baremetal_0",
-					OS:           "ubuntu_16_04",
-					Facility:     []string{"ewr1"},
+					Plan:         testPlan,
+					OS:           testOS,
+					Facility:     []string{testFacility()},
 					BillingCycle: "hourly",
 					Tags:         []string{"abc"},
 				},

--- a/bgp_neighbors_test.go
+++ b/bgp_neighbors_test.go
@@ -11,10 +11,10 @@ func createBGPDevice(t *testing.T, c *Client, projectID string) *Device {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{testFacility()},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 	}
 	d, _, err := c.Devices.Create(&cr)
 	if err != nil {

--- a/bgp_sessions_test.go
+++ b/bgp_sessions_test.go
@@ -25,10 +25,10 @@ func TestAccBGPSession(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{testFacility()},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 	}
 
 	d, _, err := c.Devices.Create(&cr)

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -14,7 +14,7 @@ func TestAccCheckCapacity(t *testing.T) {
 		[]ServerInfo{
 			{
 				Facility: "ams1",
-				Plan:     "baremetal_0",
+				Plan:     testPlan,
 				Quantity: 1},
 		},
 	}

--- a/devices_test.go
+++ b/devices_test.go
@@ -85,8 +85,8 @@ func TestAccDeviceUpdate(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}
@@ -135,8 +135,8 @@ func TestAccDeviceBasic(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "t1.small.x86",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		Description:  "test",
@@ -209,7 +209,7 @@ func TestAccDevicePXE(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:      "pxe-" + hn,
 		Facility:      []string{fac},
-		Plan:          "baremetal_0",
+		Plan:          testPlan,
 		ProjectID:     projectID,
 		BillingCycle:  "hourly",
 		OS:            "custom_ipxe",
@@ -274,10 +274,10 @@ func TestAccDeviceAssignGlobalIP(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 	}
 
 	d, _, err := c.Devices.Create(&cr)
@@ -401,10 +401,10 @@ func TestAccDeviceCreateWithReservedIP(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 		IPAddresses: []IPAddressCreateRequest{
 			// NOTE: only one public IPv4 entry is allowed here
 			{AddressFamily: 4, Public: false},
@@ -444,10 +444,10 @@ func TestAccDeviceAssignIP(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 	}
 
 	d, _, err := c.Devices.Create(&cr)
@@ -574,10 +574,10 @@ func TestAccDeviceAttachVolumeForceDelete(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 	}
 
 	d, _, err := c.Devices.Create(&cr)
@@ -640,10 +640,10 @@ func TestAccDeviceAttachVolume(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
+		Plan:         testPlan,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 	}
 
 	d, _, err := c.Devices.Create(&cr)
@@ -721,7 +721,7 @@ func TestAccDeviceSpotInstance(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:        hn,
 		Facility:        []string{fac},
-		Plan:            "baremetal_0",
+		Plan:            testPlan,
 		OS:              "coreos_stable",
 		ProjectID:       projectID,
 		BillingCycle:    "hourly",
@@ -767,8 +767,8 @@ func TestAccDeviceCustomData(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		CustomData:   initialCustomData,
@@ -842,8 +842,8 @@ func TestAccListDeviceEvents(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		CustomData:   initialCustomData,
@@ -881,8 +881,8 @@ func TestAccDeviceSSHKeys(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{testFacility()},
-		Plan:         "baremetal_0",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}
@@ -932,8 +932,8 @@ func TestAccDeviceListedSSHKeys(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:       hn,
 		Facility:       []string{testFacility()},
-		Plan:           "baremetal_0",
-		OS:             "ubuntu_16_04",
+		Plan:           testPlan,
+		OS:             testOS,
 		ProjectID:      projectID,
 		BillingCycle:   "hourly",
 		ProjectSSHKeys: []string{projectKey.ID},
@@ -988,8 +988,8 @@ func TestAccDeviceCreateFacilities(t *testing.T) {
 
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
-		Plan:         "baremetal_0",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		Facility:     facilities,
@@ -1031,8 +1031,8 @@ func TestAccDeviceIPAddresses(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         "baremetal_0",
-		OS:           "ubuntu_16_04",
+		Plan:         testPlan,
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		IPAddresses: []IPAddressCreateRequest{

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -27,6 +27,12 @@ const (
 	testRecorderDisabled = "disabled"
 
 	recorderDefaultMode = recorder.ModeDisabled
+
+	// defaults should be available to most users
+	testFacilityDefault   = "ny5"
+	testFacilityAlternate = "dc13"
+	testPlan              = "c3.small.x86"
+	testOS                = "ubuntu_16_04"
 )
 
 func testFacility() string {
@@ -34,7 +40,7 @@ func testFacility() string {
 	if envFac != "" {
 		return envFac
 	}
-	return "ewr1"
+	return testFacilityDefault
 }
 
 func randString8() string {

--- a/ports_test.go
+++ b/ports_test.go
@@ -28,7 +28,7 @@ func TestAccPort1E(t *testing.T) {
 		Hostname:     hn,
 		Facility:     []string{fac},
 		Plan:         "baremetal_1e",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}
@@ -154,7 +154,7 @@ func testL2HybridL3Convert(t *testing.T, plan string) {
 		Hostname:     hn,
 		Facility:     []string{fac},
 		Plan:         plan,
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}
@@ -312,7 +312,7 @@ func testL2L3Convert(t *testing.T, plan string) {
 		Hostname:     hn,
 		Facility:     []string{fac},
 		Plan:         plan,
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}
@@ -477,7 +477,7 @@ func TestAccPortNetworkStateTransitions(t *testing.T) {
 		Hostname:     "networktypetest",
 		Facility:     []string{fac},
 		Plan:         "m1.xlarge.x86",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}
@@ -528,7 +528,7 @@ func TestAccPortNativeVlan(t *testing.T) {
 		Hostname:     "networktypetest",
 		Facility:     []string{fac},
 		Plan:         "baremetal_2",
-		OS:           "ubuntu_16_04",
+		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 	}

--- a/spotmarketrequest_test.go
+++ b/spotmarketrequest_test.go
@@ -17,16 +17,17 @@ func TestAccSpotMarketRequestBasic(t *testing.T) {
 	defer teardown()
 
 	hn := randString8()
+	fac := testFacility()
 
 	ps := SpotMarketRequestInstanceParameters{
 		BillingCycle:    "hourly",
-		Plan:            "baremetal_0",
+		Plan:            testPlan,
 		OperatingSystem: "rancher",
 		Hostname:        fmt.Sprintf("%s{{index}}", hn),
 	}
 
 	prices, _, err := c.SpotMarket.Prices()
-	pri := prices["ewr1"]["baremetal_0"]
+	pri := prices[fac][testPlan]
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +35,7 @@ func TestAccSpotMarketRequestBasic(t *testing.T) {
 	cr := SpotMarketRequestCreateRequest{
 		DevicesMax:  3,
 		DevicesMin:  2,
-		FacilityIDs: []string{"ewr1", "sjc1"},
+		FacilityIDs: []string{fac, testFacilityAlternate},
 		MaxBidPrice: pri / 2,
 		Parameters:  ps,
 	}
@@ -59,8 +60,8 @@ func TestAccSpotMarketRequestBasic(t *testing.T) {
 		t.Fatal("there should be only one SpotMarketRequest")
 	}
 
-	if smrs[0].Plan.Slug != "t1.small.x86" {
-		t.Fatal("Plan should be reported as t1.small.x86 (aka baremetal_0).")
+	if smrs[0].Plan.Slug != testPlan {
+		t.Fatalf("Plan should be reported as %s", testPlan)
 	}
 
 	smr2, _, err := c.SpotMarketRequests.Get(smr.ID, nil)
@@ -83,13 +84,14 @@ func TestAccSpotMarketRequestPriceAware(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pri := prices["ewr1"]["baremetal_0"]
+	fac := testFacility()
+	pri := prices[fac][testPlan]
 	thr := pri * 2.0
 	hn := randString8()
 
 	ps := SpotMarketRequestInstanceParameters{
 		BillingCycle:    "hourly",
-		Plan:            "baremetal_0",
+		Plan:            testPlan,
 		OperatingSystem: "rancher",
 		Hostname:        fmt.Sprintf("%s{{index}}", hn),
 	}
@@ -99,7 +101,7 @@ func TestAccSpotMarketRequestPriceAware(t *testing.T) {
 	cr := SpotMarketRequestCreateRequest{
 		DevicesMax:  nDevices,
 		DevicesMin:  nDevices,
-		FacilityIDs: []string{"ewr1"},
+		FacilityIDs: []string{fac},
 		MaxBidPrice: thr,
 		Parameters:  ps,
 	}

--- a/vpn_test.go
+++ b/vpn_test.go
@@ -29,7 +29,7 @@ func TestAccVPN(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = c.VPN.Get("ewr1", nil)
+	_, _, err = c.VPN.Get(testFacility(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
New Equinix Metal users will not have access to legacy Packet plans and
facilities. Let's not base our tests on access to those resources.

Fixes #201

Signed-off-by: Marques Johansson <marques@packet.com>