### PR TITLE
tests: change default OS for tests to Ubuntu 18.04 LTS

### DIFF
--- a/packngo_test.go
+++ b/packngo_test.go
@@ -32,7 +32,7 @@ const (
 	testFacilityDefault   = "ny5"
 	testFacilityAlternate = "dc13"
 	testPlan              = "c3.small.x86"
-	testOS                = "ubuntu_16_04"
+	testOS                = "ubuntu_18_04"
 )
 
 func testFacility() string {


### PR DESCRIPTION
Applies @t0mk's recommendation from https://github.com/packethost/packngo/pull/202 to revise the default OS in testing to a newer Ubuntu.