### PR TITLE
add Search to ListOptions

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -322,8 +322,17 @@ type DeviceServiceOp struct {
 }
 
 // List returns devices on a project
+//
+// Regarding ListOptions.Search: The API documentation does not provide guidance
+// on the fields that will be searched using this parameter, so this behavior is
+// undefined and prone to change.
+//
+// As of 2020-10-20, ListOptions.Search will look for matches in the following
+// Device properties: Hostname, Description, Tags, ID, ShortID, Network.Address,
+// Plan.Name, Plan.Slug, Facility.Code, Facility.Name, OS.Name, OS.Slug,
+// HardwareReservation.ID, HardwareReservation.ShortID
 func (s *DeviceServiceOp) List(projectID string, listOpt *ListOptions) (devices []Device, resp *Response, err error) {
-	listOpt = makeSureListOptionsInclude(listOpt, "facility")
+	listOpt = listOpt.Including("facility")
 	params := urlQuery(listOpt)
 	path := fmt.Sprintf("%s/%s%s?%s", projectBasePath, projectID, deviceBasePath, params)
 
@@ -351,7 +360,7 @@ func (s *DeviceServiceOp) List(projectID string, listOpt *ListOptions) (devices 
 
 // Get returns a device by id
 func (s *DeviceServiceOp) Get(deviceID string, getOpt *GetOptions) (*Device, *Response, error) {
-	getOpt = makeSureGetOptionsInclude(getOpt, "facility")
+	getOpt = getOpt.Including("facility")
 	params := urlQuery(getOpt)
 
 	path := fmt.Sprintf("%s/%s?%s", deviceBasePath, deviceID, params)

--- a/packngo.go
+++ b/packngo.go
@@ -144,24 +144,52 @@ type OptionsGetter interface {
 	GetOptions() *GetOptions
 }
 
-func makeSureGetOptionsInclude(g *GetOptions, s string) *GetOptions {
+// Including ensures that the variadic refs are included in a copy of the
+// options, resulting in expansion of the the referred sub-resources. Unknown
+// values within refs will be silently ignore by the API.
+func (g *GetOptions) Including(refs ...string) *GetOptions {
 	if g == nil {
-		return &GetOptions{Includes: []string{s}}
+		return &GetOptions{Includes: refs}
 	}
-	if !contains(g.Includes, s) {
-		g.Includes = append(g.Includes, s)
+	out := *g
+	for _, v := range refs {
+		if !contains(out.Includes, v) {
+			out.Includes = append(out.Includes, v)
+		}
 	}
-	return g
+	return &out
 }
 
-func makeSureListOptionsInclude(l *ListOptions, s string) *ListOptions {
+// Including ensures that the variadic refs are included in a copy of the
+// options, resulting in expansion of the the referred sub-resources. Unknown
+// values within refs will be silently ignore by the API.
+func (l *ListOptions) Including(refs ...string) *ListOptions {
 	if l == nil {
-		return &ListOptions{Includes: []string{s}}
+		return &ListOptions{Includes: refs}
 	}
-	if !contains(l.Includes, s) {
-		l.Includes = append(l.Includes, s)
+	out := *l
+	for _, v := range refs {
+		if !contains(out.Includes, v) {
+			out.Includes = append(out.Includes, v)
+		}
 	}
-	return l
+	return &out
+}
+
+// Including ensures that the variadic refs are included in a copy of the
+// options, resulting in expansion of the the referred sub-resources. Unknown
+// values within refs will be silently ignore by the API.
+func (s *SearchOptions) Including(refs ...string) *SearchOptions {
+	if s == nil {
+		return &SearchOptions{Includes: refs}
+	}
+	out := *s
+	for _, v := range refs {
+		if !contains(out.Includes, v) {
+			out.Includes = append(out.Includes, v)
+		}
+	}
+	return &out
 }
 
 type paramsReady interface {

--- a/packngo.go
+++ b/packngo.go
@@ -87,6 +87,14 @@ type ListOptions struct {
 	// PerPage is the number of results to return per page for paginated result
 	// sets,
 	PerPage int `url:"per_page,omitempty"`
+
+	// Search is a special API query parameter that, for resources that support
+	// it, will filter results to those with any one of various fields matching
+	// the supplied keyword.  For example, a resource may have a defined search
+	// behavior matches either a name or a fingerprint field, while another
+	// resource may match entirely different fields.  Search is currently
+	// implemented for SSHKeys and uses an exact match.
+	Search string `url:"search,omitempty"`
 }
 
 // GetOptions returns GetOptions from ListOptions (and is nil-receiver safe)
@@ -100,7 +108,8 @@ func (l *ListOptions) GetOptions() *GetOptions {
 }
 
 // SearchOptions are options common to API GET requests that include a
-// multi-field search filter.
+// multi-field search filter. SearchOptions are used in List functions that are
+// known to support `search` but do not offer pagination.
 type SearchOptions struct {
 	// avoid embedding GetOptions (for similar behavior to ListOptions)
 
@@ -200,6 +209,10 @@ func (l *ListOptions) Params() url.Values {
 	}
 	if l.PerPage != 0 {
 		params.Set("per_page", fmt.Sprintf("%d", l.PerPage))
+	}
+
+	if l.Search != "" {
+		params.Set("search", l.Search)
 	}
 
 	return params


### PR DESCRIPTION
The paginated devices endpoint includes support for the search parameter. This PR adds the Search parameter for all ListOptions, making the field available for packngo developers despite any guidance on where and how the parameter is actually applied.  Using `search` when it is not supported does not trigger any errors.

For the Device.List function, I have included the current list of values that are considered for search. This should help users to decide if this field can benefit their use-case. 

However, the search parameter is currently undocumented, which means that depending on specific behaviors can not be guaranteed.  Nonetheless, where the search parameter is accepted this will result in some 'search' behavior.

In practice, this should greatly alleviate the performance problems identified in  https://github.com/packethost/terraform-provider-packet/issues/276

--


This PR also makes the internal `makeSureGetOptionsInclude` set of functions public by creating an `Including` method on GetOptions/ListOptions/SearchOptions.