### PR TITLE
make test plan configurable from envvar, fix spotmarket_request test

### DIFF
--- a/batches_test.go
+++ b/batches_test.go
@@ -16,7 +16,7 @@ func TestAccInstanceBatches(t *testing.T) {
 			{
 				DeviceCreateRequest: DeviceCreateRequest{
 					Hostname:     "test1",
-					Plan:         testPlan,
+					Plan:         testPlan(),
 					OS:           testOS,
 					Facility:     []string{testFacility()},
 					BillingCycle: "hourly",

--- a/bgp_neighbors_test.go
+++ b/bgp_neighbors_test.go
@@ -11,7 +11,7 @@ func createBGPDevice(t *testing.T, c *Client, projectID string) *Device {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{testFacility()},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,

--- a/bgp_sessions_test.go
+++ b/bgp_sessions_test.go
@@ -25,7 +25,7 @@ func TestAccBGPSession(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{testFacility()},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,

--- a/capacities_test.go
+++ b/capacities_test.go
@@ -14,7 +14,7 @@ func TestAccCheckCapacity(t *testing.T) {
 		[]ServerInfo{
 			{
 				Facility: "ams1",
-				Plan:     testPlan,
+				Plan:     testPlan(),
 				Quantity: 1},
 		},
 	}

--- a/devices_test.go
+++ b/devices_test.go
@@ -64,12 +64,6 @@ func deleteDevice(t *testing.T, c *Client, id string, force bool) {
 	}
 }
 
-func deleteSpotMarketRequest(t *testing.T, c *Client, id string, force bool) {
-	if _, err := c.SpotMarketRequests.Delete(id, force); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func deleteSSHKey(t *testing.T, c *Client, id string) {
 	if _, err := c.SSHKeys.Delete(id); err != nil {
 		t.Fatal(err)
@@ -113,7 +107,7 @@ func TestAccDeviceUpdate(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
@@ -163,7 +157,7 @@ func TestAccDeviceBasic(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
@@ -237,7 +231,7 @@ func TestAccDevicePXE(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:      "pxe-" + hn,
 		Facility:      []string{fac},
-		Plan:          testPlan,
+		Plan:          testPlan(),
 		ProjectID:     projectID,
 		BillingCycle:  "hourly",
 		OS:            "custom_ipxe",
@@ -302,7 +296,7 @@ func TestAccDeviceAssignGlobalIP(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,
@@ -429,7 +423,7 @@ func TestAccDeviceCreateWithReservedIP(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,
@@ -472,7 +466,7 @@ func TestAccDeviceAssignIP(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,
@@ -602,7 +596,7 @@ func TestAccDeviceAttachVolumeForceDelete(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,
@@ -668,7 +662,7 @@ func TestAccDeviceAttachVolume(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
 		OS:           testOS,
@@ -749,7 +743,7 @@ func TestAccDeviceSpotInstance(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:        hn,
 		Facility:        []string{fac},
-		Plan:            testPlan,
+		Plan:            testPlan(),
 		OS:              "coreos_stable",
 		ProjectID:       projectID,
 		BillingCycle:    "hourly",
@@ -795,7 +789,7 @@ func TestAccDeviceCustomData(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
@@ -870,7 +864,7 @@ func TestAccListDeviceEvents(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
@@ -909,7 +903,7 @@ func TestAccDeviceSSHKeys(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{testFacility()},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
@@ -960,7 +954,7 @@ func TestAccDeviceListedSSHKeys(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:       hn,
 		Facility:       []string{testFacility()},
-		Plan:           testPlan,
+		Plan:           testPlan(),
 		OS:             testOS,
 		ProjectID:      projectID,
 		BillingCycle:   "hourly",
@@ -1016,7 +1010,7 @@ func TestAccDeviceCreateFacilities(t *testing.T) {
 
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",
@@ -1059,7 +1053,7 @@ func TestAccDeviceIPAddresses(t *testing.T) {
 	cr := DeviceCreateRequest{
 		Hostname:     hn,
 		Facility:     []string{fac},
-		Plan:         testPlan,
+		Plan:         testPlan(),
 		OS:           testOS,
 		ProjectID:    projectID,
 		BillingCycle: "hourly",

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -20,6 +20,7 @@ const (
 	packngoAccTestVar = "PACKNGO_TEST_ACTUAL_API"
 	testProjectPrefix = "PACKNGO_TEST_DELME_2d768716_"
 	testFacilityVar   = "PACKNGO_TEST_FACILITY"
+	testPlanVar       = "PACKNGO_TEST_PLAN"
 	testRecorderEnv   = "PACKNGO_TEST_RECORDER"
 
 	testRecorderRecord   = "record"
@@ -31,9 +32,17 @@ const (
 	// defaults should be available to most users
 	testFacilityDefault   = "ny5"
 	testFacilityAlternate = "dc13"
-	testPlan              = "c3.small.x86"
+	testPlanDefault       = "c3.small.x86"
 	testOS                = "ubuntu_18_04"
 )
+
+func testPlan() string {
+	envPlan := os.Getenv(testPlanVar)
+	if envPlan != "" {
+		return envPlan
+	}
+	return testPlanDefault
+}
 
 func testFacility() string {
 	envFac := os.Getenv(testFacilityVar)

--- a/spotmarketrequest_test.go
+++ b/spotmarketrequest_test.go
@@ -51,7 +51,7 @@ func TestAccSpotMarketRequestBasic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	deleteSpotMarketRequest(t, c, smr.ID, true)
+	defer deleteSpotMarketRequest(t, c, smr.ID, true)
 
 	if smr.Project.ID != projectID {
 		t.Fatal("Strange project ID in SpotMarketReuqest:", smr.Project.ID)
@@ -67,7 +67,7 @@ func TestAccSpotMarketRequestBasic(t *testing.T) {
 	}
 
 	if smrs[0].Plan.Slug != testPlan() {
-		t.Fatalf("Plan should be reported as %s", testPlan())
+		t.Fatalf("Plan should be reported as %s, was %s", testPlan(), smrs[0].Plan.Slug)
 	}
 
 	smr2, _, err := c.SpotMarketRequests.Get(smr.ID, nil)


### PR DESCRIPTION
This PR adds support for envvar PACKNGO_TEST_PLAN to choose which plan to use in acceptance tests. It also fixes acceptance tests for sportmarket_request.

Sorry that these 2 fixes are together. I tried to git add -p chunks, but it was too much of a mess.

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>