### PR TITLE
IPReservationRequest: change type of attribute CustomData to interface{}

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -87,12 +87,12 @@ type IPAddressAssignment struct {
 
 // IPReservationRequest represents the body of a reservation request.
 type IPReservationRequest struct {
-	Type        string                 `json:"type"`
-	Quantity    int                    `json:"quantity"`
-	Description string                 `json:"details,omitempty"`
-	Facility    *string                `json:"facility,omitempty"`
-	Tags        []string               `json:"tags,omitempty"`
-	CustomData  map[string]interface{} `json:"customdata,omitempty"`
+	Type        string   `json:"type"`
+	Quantity    int      `json:"quantity"`
+	Description string   `json:"details,omitempty"`
+	Facility    *string  `json:"facility,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	CustomData  *string  `json:"customdata,omitempty"`
 	// FailOnApprovalRequired if the IP request cannot be approved automatically, rather than sending to
 	// the longer Equinix Metal approval process, fail immediately with a 422 error
 	FailOnApprovalRequired bool `json:"fail_on_approval_required,omitempty"`

--- a/ip.go
+++ b/ip.go
@@ -39,23 +39,23 @@ type ProjectIPService interface {
 }
 
 type IpAddressCommon struct { //nolint:golint
-	ID            string                 `json:"id"`
-	Address       string                 `json:"address"`
-	Gateway       string                 `json:"gateway"`
-	Network       string                 `json:"network"`
-	AddressFamily int                    `json:"address_family"`
-	Netmask       string                 `json:"netmask"`
-	Public        bool                   `json:"public"`
-	CIDR          int                    `json:"cidr"`
-	Created       string                 `json:"created_at,omitempty"`
-	Updated       string                 `json:"updated_at,omitempty"`
-	Href          string                 `json:"href"`
-	Management    bool                   `json:"management"`
-	Manageable    bool                   `json:"manageable"`
-	Project       Href                   `json:"project"`
-	Global        *bool                  `json:"global_ip"`
-	Tags          []string               `json:"tags,omitempty"`
-	CustomData    map[string]interface{} `json:"customdata,omitempty"`
+	ID            string      `json:"id"`
+	Address       string      `json:"address"`
+	Gateway       string      `json:"gateway"`
+	Network       string      `json:"network"`
+	AddressFamily int         `json:"address_family"`
+	Netmask       string      `json:"netmask"`
+	Public        bool        `json:"public"`
+	CIDR          int         `json:"cidr"`
+	Created       string      `json:"created_at,omitempty"`
+	Updated       string      `json:"updated_at,omitempty"`
+	Href          string      `json:"href"`
+	Management    bool        `json:"management"`
+	Manageable    bool        `json:"manageable"`
+	Project       Href        `json:"project"`
+	Global        *bool       `json:"global_ip"`
+	Tags          []string    `json:"tags,omitempty"`
+	CustomData    interface{} `json:"customdata,omitempty"`
 }
 
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).
@@ -87,12 +87,12 @@ type IPAddressAssignment struct {
 
 // IPReservationRequest represents the body of a reservation request.
 type IPReservationRequest struct {
-	Type        string   `json:"type"`
-	Quantity    int      `json:"quantity"`
-	Description string   `json:"details,omitempty"`
-	Facility    *string  `json:"facility,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	CustomData  *string  `json:"customdata,omitempty"`
+	Type        string      `json:"type"`
+	Quantity    int         `json:"quantity"`
+	Description string      `json:"details,omitempty"`
+	Facility    *string     `json:"facility,omitempty"`
+	Tags        []string    `json:"tags,omitempty"`
+	CustomData  interface{} `json:"customdata,omitempty"`
 	// FailOnApprovalRequired if the IP request cannot be approved automatically, rather than sending to
 	// the longer Equinix Metal approval process, fail immediately with a 422 error
 	FailOnApprovalRequired bool `json:"fail_on_approval_required,omitempty"`

--- a/ip_test.go
+++ b/ip_test.go
@@ -1,7 +1,6 @@
 package packngo
 
 import (
-	"encoding/json"
 	"path"
 	"reflect"
 	"testing"
@@ -27,7 +26,7 @@ func TestAccPublicIPReservation(t *testing.T) {
 		t.Fatalf("There should be no reservations a new project, existing list: %s", ipList)
 	}
 
-	customData := `{"custom1":"data","custom2":{"nested":"data"}}`
+	customData := map[string]interface{}{"custom1": "data", "custom2": map[string]interface{}{"nested": "data"}}
 	tags := []string{"Tag1", "Tag2"}
 
 	req := IPReservationRequest{
@@ -64,15 +63,8 @@ func TestAccPublicIPReservation(t *testing.T) {
 			res.Facility.Code)
 	}
 
-	bytesCustomData, err := json.Marshal(res.CustomData)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	responseCustomData := string(bytesCustomData)
-
-	if customData != responseCustomData {
-		t.Fatalf("CustomData of new reservation should be %+v, was %+v", customData, responseCustomData)
+	if !reflect.DeepEqual(customData, res.CustomData) {
+		t.Fatalf("CustomData of new reservation should be %+v, was %+v", customData, res.CustomData)
 	}
 
 	if !reflect.DeepEqual(tags, res.Tags) {
@@ -224,7 +216,7 @@ func TestAccPublicIPReservationFailFast(t *testing.T) {
 	// this should be an absurdly high number
 	quantity := 256
 
-	customData := `{"custom1":"data","custom2":{"nested":"data"}}`
+	customData := map[string]interface{}{"custom1": "data", "custom2": map[string]interface{}{"nested": "data"}}
 
 	req := IPReservationRequest{
 		Type:                   PublicIPv4,


### PR DESCRIPTION
This PR changes type of CustomData from map[string]interface{} to string in struct for creating IP reservation. There is no presrcibed form for custom_data, so there's no reason to assume that it should be a map. 

Also, custom_data of device resource is already a string.

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>