### PR TITLE
Enable default golangci linters via drone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	$(GO) go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
+	$(GO) go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
 endif
 
 golint:
@@ -27,7 +27,7 @@ ifeq (, $(shell which golint))
 endif
 
 lint: golint golangci-lint
-	$(GO) golangci-lint run --disable-all --enable=golint ./...
+	$(GO) golangci-lint run ./...
 	$(GO) go vet ./...
 	$(GO) gofmt -d .
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMG ?= golang:1.14
+IMG ?= golang:1.15
 
 # enable go modules, disabled CGO
 

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a
 )
 
-go 1.14
+go 1.15

--- a/ports.go
+++ b/ports.go
@@ -1,11 +1,9 @@
 package packngo
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"strings"
-	"time"
 )
 
 const portBasePath = "/ports"
@@ -308,33 +306,6 @@ func (i *DevicePortServiceOp) ConvertDevice(d *Device, targetType string) error 
 		}
 	}
 	return nil
-}
-
-// waitDeviceNetworkType waits for a device's computed network type (as
-// determined by GetNetworkType()) to reach the specified state. An error will
-// be returned if the device does not attain the desired network type state when
-// the timeout is reached without
-func waitDeviceNetworkType(id, networkType string, c *Client) (*Device, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(15)*time.Minute)
-	defer cancel()
-
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			d, _, err := c.Devices.Get(id, nil)
-			if err != nil {
-				return nil, err
-			}
-			if d.GetNetworkType() == networkType {
-				return d, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("device %s is still not in state %s after timeout", id, networkType)
-		}
-	}
 }
 
 func (i *DevicePortServiceOp) DeviceToNetworkType(deviceID string, targetType string) (*Device, error) {


### PR DESCRIPTION
* Enable default golangci linters via drone
* Updates golangci-lint to latest
* Updates go to 1.15 from 1.14
* Removes deadcode: `waitDeviceNetworkType` (to pass linting)