### PR TITLE
breaking: define CustomData as interface{} in Device and IPAddressCommon

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -67,10 +67,16 @@ type Device struct {
 	SpotPriceMax        float64                `json:"spot_price_max,omitempty"`
 	TerminationTime     *Timestamp             `json:"termination_time,omitempty"`
 	NetworkPorts        []Port                 `json:"network_ports,omitempty"`
-	CustomData          map[string]interface{} `json:"customdata,omitempty"`
 	SSHKeys             []SSHKey               `json:"ssh_keys,omitempty"`
 	ShortID             string                 `json:"short_id,omitempty"`
 	SwitchUUID          string                 `json:"switch_uuid,omitempty"`
+
+	// CustomData, as handled by the API, can be any JSON scalar or struct
+	// value. This value can be used to store arbitrary notes or data relevant
+	// to the device.  CustomData is made available to the device, via the
+	// metadata service, as a `customdata` JSON field at
+	// https://metadata.platformequinix.com/metadata.
+	CustomData interface{} `json:"customdata,omitempty"`
 }
 
 type NetworkInfo struct {

--- a/ip.go
+++ b/ip.go
@@ -40,23 +40,27 @@ type ProjectIPService interface {
 }
 
 type IpAddressCommon struct { //nolint:golint
-	ID            string      `json:"id"`
-	Address       string      `json:"address"`
-	Gateway       string      `json:"gateway"`
-	Network       string      `json:"network"`
-	AddressFamily int         `json:"address_family"`
-	Netmask       string      `json:"netmask"`
-	Public        bool        `json:"public"`
-	CIDR          int         `json:"cidr"`
-	Created       string      `json:"created_at,omitempty"`
-	Updated       string      `json:"updated_at,omitempty"`
-	Href          string      `json:"href"`
-	Management    bool        `json:"management"`
-	Manageable    bool        `json:"manageable"`
-	Project       Href        `json:"project"`
-	Global        *bool       `json:"global_ip"`
-	Tags          []string    `json:"tags,omitempty"`
-	CustomData    interface{} `json:"customdata,omitempty"`
+	ID            string   `json:"id"`
+	Address       string   `json:"address"`
+	Gateway       string   `json:"gateway"`
+	Network       string   `json:"network"`
+	AddressFamily int      `json:"address_family"`
+	Netmask       string   `json:"netmask"`
+	Public        bool     `json:"public"`
+	CIDR          int      `json:"cidr"`
+	Created       string   `json:"created_at,omitempty"`
+	Updated       string   `json:"updated_at,omitempty"`
+	Href          string   `json:"href"`
+	Management    bool     `json:"management"`
+	Manageable    bool     `json:"manageable"`
+	Project       Href     `json:"project"`
+	Global        *bool    `json:"global_ip"`
+	Tags          []string `json:"tags,omitempty"`
+
+	// CustomData, as handled by the API, can be any JSON scalar or struct
+	// value. This value can be used to store arbitrary notes or data relevant
+	// to the IP.
+	CustomData interface{} `json:"customdata,omitempty"`
 }
 
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).


### PR DESCRIPTION
The API will accept and return CustomData with any JSON value or
structure. The previous type (map[string]interface{}) did not allow for
string only values, which are acceptable, as are ints, bools, and null.

Signed-off-by: Marques Johansson <mjohansson@equinix.com>