### PR TITLE
Support for Connection API resource

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -1,0 +1,100 @@
+package packngo
+
+import (
+	"path"
+)
+
+const (
+	connectionBasePath = "/connections"
+)
+
+type ConnectionService interface {
+	OrganizationCreate(string, *ConnectionCreateRequest) (*Connection, *Response, error)
+	ProjectCreate(string, *ConnectionCreateRequest) (*Connection, *Response, error)
+	OrganizationList(string, *GetOptions) ([]Connection, *Response, error)
+	ProjectList(string, *GetOptions) ([]Connection, *Response, error)
+}
+
+type ConnectionServiceOp struct {
+	client *Client
+}
+
+type connectionsRoot struct {
+	Connections []Connection `json:"connections"`
+	Meta        meta         `json:"meta"`
+}
+
+type Connection struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Redundancy  string   `json:"redundancy,omitempty"`
+	Facility    string   `json:"facility,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Project     string   `json:"string,omitempty"`
+	Speed       string   `json:"speed,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+type ConnectionCreateRequest struct {
+	Name        string   `json:"name,omitempty"`
+	Redundancy  string   `json:"redundancy,omitempty"`
+	Facility    string   `json:"facility,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Project     string   `json:"string,omitempty"`
+	Speed       string   `json:"speed,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+func (s *ConnectionServiceOp) create(apiUrl string, createRequest *ConnectionCreateRequest) (*Connection, *Response, error) {
+	connection := new(Connection)
+	resp, err := s.client.DoRequest("POST", apiUrl, createRequest, connection)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return connection, resp, err
+}
+
+func (s *ConnectionServiceOp) OrganizationCreate(id string, createRequest *ConnectionCreateRequest) (*Connection, *Response, error) {
+	apiUrl := path.Join(organizationBasePath, id, connectionBasePath)
+	return s.create(apiUrl, createRequest)
+}
+
+func (s *ConnectionServiceOp) ProjectCreate(id string, createRequest *ConnectionCreateRequest) (*Connection, *Response, error) {
+	apiUrl := path.Join(projectBasePath, id, connectionBasePath)
+	return s.create(apiUrl, createRequest)
+}
+
+func (s *ConnectionServiceOp) list(url string, opts *GetOptions) (connections []Connection, resp *Response, err error) {
+	apiPathQuery := opts.WithQuery(url)
+
+	for {
+		subset := new(connectionsRoot)
+
+		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, subset)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		connections = append(connections, subset.Connections...)
+
+		if apiPathQuery = nextPage(subset.Meta, opts); apiPathQuery != "" {
+			continue
+		}
+
+		return
+	}
+
+}
+
+func (s *ConnectionServiceOp) OrganizationList(id string, opts *GetOptions) ([]Connection, *Response, error) {
+	apiUrl := path.Join(organizationBasePath, id, connectionBasePath)
+	return s.list(apiUrl, opts)
+}
+
+func (s *ConnectionServiceOp) ProjectList(id string, opts *GetOptions) ([]Connection, *Response, error) {
+	apiUrl := path.Join(projectBasePath, id, connectionBasePath)
+	return s.list(apiUrl, opts)
+}

--- a/connections.go
+++ b/connections.go
@@ -4,8 +4,16 @@ import (
 	"path"
 )
 
+type ConnectionRedundancy string
+type ConnectionType string
+
 const (
-	connectionBasePath = "/connections"
+	connectionBasePath                           = "/connections"
+	virtualCircuitsBasePath                      = "/virtual-circuits"
+	ConnectionShared        ConnectionType       = "shared"
+	ConnectionDedicated     ConnectionType       = "dedicated"
+	ConnectionRedundant     ConnectionRedundancy = "redundant"
+	ConnectionPrimary       ConnectionRedundancy = "primary"
 )
 
 type ConnectionService interface {
@@ -13,38 +21,82 @@ type ConnectionService interface {
 	ProjectCreate(string, *ConnectionCreateRequest) (*Connection, *Response, error)
 	OrganizationList(string, *GetOptions) ([]Connection, *Response, error)
 	ProjectList(string, *GetOptions) ([]Connection, *Response, error)
+	Delete(string) (*Response, error)
+	Get(string, *GetOptions) (*Connection, *Response, error)
+	Events(string, *GetOptions) ([]Event, *Response, error)
+	Ports(string, *GetOptions) ([]ConnectionPort, *Response, error)
+	Port(string, string, *GetOptions) (*ConnectionPort, *Response, error)
+	VirtualCircuits(string, string, *GetOptions) ([]ConnectionVirtualCircuit, *Response, error)
+	VirtualCircuit(string, *GetOptions) (*ConnectionVirtualCircuit, *Response, error)
+	DeleteVirtualCircuit(string) (*Response, error)
 }
 
 type ConnectionServiceOp struct {
 	client *Client
 }
 
+type connectionPortsRoot struct {
+	Ports []ConnectionPort `json:"ports"`
+}
+
+type virtualCircuitsRoot struct {
+	VirtualCircuits []ConnectionVirtualCircuit `json:"virtual_circuits"`
+	Meta            meta                       `json:"meta"`
+}
+
 type connectionsRoot struct {
-	Connections []Connection `json:"connections"`
+	Connections []Connection `json:"interconnections"`
 	Meta        meta         `json:"meta"`
 }
 
+type ConnectionVirtualCircuit struct {
+	ID      string          `json:"id"`
+	Name    string          `json:"name,omitempty"`
+	Status  string          `json:"status,omitempty"`
+	VNID    string          `json:"vnid,omitempty"`
+	NniVNID string          `json:"nni_vnid,omitempty"`
+	NniVLAN string          `json:"nni_vlan,omitempty"`
+	Project *Project        `json:"project,omitempty"`
+	Port    *ConnectionPort `json:"port,omitempty"`
+}
+
+type ConnectionPort struct {
+	ID              string                     `json:"id"`
+	Name            string                     `json:"name,omitempty"`
+	Status          string                     `json:"status,omitempty"`
+	Role            string                     `json:"role,omitempty"`
+	Speed           string                     `json:"speed,omitempty"`
+	Organization    *Organization              `json:"organization,omitempty"`
+	VirtualCircuits []ConnectionVirtualCircuit `json:"virtual_circuits,omitempty"`
+	LinkStatus      string                     `json:"link_status,omitempty"`
+	Href            string                     `json:"href,omitempty"`
+}
+
 type Connection struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name,omitempty"`
-	Redundancy  string   `json:"redundancy,omitempty"`
-	Facility    string   `json:"facility,omitempty"`
-	Type        string   `json:"type,omitempty"`
-	Description *string  `json:"description,omitempty"`
-	Project     string   `json:"string,omitempty"`
-	Speed       string   `json:"speed,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
+	ID           string               `json:"id"`
+	Name         string               `json:"name,omitempty"`
+	Status       string               `json:"status,omitempty"`
+	Redundancy   ConnectionRedundancy `json:"redundancy,omitempty"`
+	Facility     *Facility            `json:"facility,omitempty"`
+	Type         ConnectionType       `json:"type,omitempty"`
+	Description  string               `json:"description,omitempty"`
+	Project      *Project             `json:"project,omitempty"`
+	Organization *Organization        `json:"organization,omitempty"`
+	Speed        string               `json:"speed,omitempty"`
+	Token        string               `json:"token,omitempty"`
+	Tags         []string             `json:"tags,omitempty"`
+	Ports        []ConnectionPort     `json:"ports,omitempty"`
 }
 
 type ConnectionCreateRequest struct {
-	Name        string   `json:"name,omitempty"`
-	Redundancy  string   `json:"redundancy,omitempty"`
-	Facility    string   `json:"facility,omitempty"`
-	Type        string   `json:"type,omitempty"`
-	Description *string  `json:"description,omitempty"`
-	Project     string   `json:"string,omitempty"`
-	Speed       string   `json:"speed,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
+	Name        string               `json:"name,omitempty"`
+	Redundancy  ConnectionRedundancy `json:"redundancy,omitempty"`
+	Facility    string               `json:"facility,omitempty"`
+	Type        ConnectionType       `json:"type,omitempty"`
+	Description *string              `json:"description,omitempty"`
+	Project     string               `json:"project,omitempty"`
+	Speed       string               `json:"speed,omitempty"`
+	Tags        []string             `json:"tags,omitempty"`
 }
 
 func (s *ConnectionServiceOp) create(apiUrl string, createRequest *ConnectionCreateRequest) (*Connection, *Response, error) {
@@ -97,4 +149,85 @@ func (s *ConnectionServiceOp) OrganizationList(id string, opts *GetOptions) ([]C
 func (s *ConnectionServiceOp) ProjectList(id string, opts *GetOptions) ([]Connection, *Response, error) {
 	apiUrl := path.Join(projectBasePath, id, connectionBasePath)
 	return s.list(apiUrl, opts)
+}
+
+func (s *ConnectionServiceOp) Delete(id string) (*Response, error) {
+	apiPath := path.Join(connectionBasePath, id)
+	return s.client.DoRequest("DELETE", apiPath, nil, nil)
+}
+
+func (s *ConnectionServiceOp) Port(connID, portID string, opts *GetOptions) (*ConnectionPort, *Response, error) {
+	endpointPath := path.Join(connectionBasePath, connID, portBasePath, portID)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	port := new(ConnectionPort)
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, port)
+	if err != nil {
+		return nil, resp, err
+	}
+	return port, resp, err
+}
+
+func (s *ConnectionServiceOp) Get(id string, opts *GetOptions) (*Connection, *Response, error) {
+	endpointPath := path.Join(connectionBasePath, id)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	connection := new(Connection)
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, connection)
+	if err != nil {
+		return nil, resp, err
+	}
+	return connection, resp, err
+}
+
+func (s *ConnectionServiceOp) Ports(connID string, opts *GetOptions) ([]ConnectionPort, *Response, error) {
+	endpointPath := path.Join(connectionBasePath, connID, portBasePath)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	ports := new(connectionPortsRoot)
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, ports)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ports.Ports, resp, nil
+
+}
+
+func (s *ConnectionServiceOp) Events(id string, opts *GetOptions) ([]Event, *Response, error) {
+	apiPath := path.Join(connectionBasePath, id, eventBasePath)
+	return listEvents(s.client, apiPath, opts)
+}
+
+func (s *ConnectionServiceOp) VirtualCircuits(connID, portID string, opts *GetOptions) (vcs []ConnectionVirtualCircuit, resp *Response, err error) {
+	endpointPath := path.Join(connectionBasePath, connID, portBasePath, portID, virtualCircuitsBasePath)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	for {
+		subset := new(virtualCircuitsRoot)
+
+		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, subset)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		vcs = append(vcs, subset.VirtualCircuits...)
+
+		if apiPathQuery = nextPage(subset.Meta, opts); apiPathQuery != "" {
+			continue
+		}
+
+		return
+	}
+}
+
+func (s *ConnectionServiceOp) VirtualCircuit(id string, opts *GetOptions) (*ConnectionVirtualCircuit, *Response, error) {
+	endpointPath := path.Join(virtualCircuitsBasePath, id)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	vc := new(ConnectionVirtualCircuit)
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, vc)
+	if err != nil {
+		return nil, resp, err
+	}
+	return vc, resp, err
+}
+
+func (s *ConnectionServiceOp) DeleteVirtualCircuit(id string) (*Response, error) {
+	apiPath := path.Join(virtualCircuitsBasePath, id)
+	return s.client.DoRequest("DELETE", apiPath, nil, nil)
 }

--- a/connections.go
+++ b/connections.go
@@ -24,6 +24,8 @@ type ConnectionService interface {
 	Delete(string) (*Response, error)
 	Get(string, *GetOptions) (*Connection, *Response, error)
 	Events(string, *GetOptions) ([]Event, *Response, error)
+	PortEvents(string, string, *GetOptions) ([]Event, *Response, error)
+	VirtualCircuitEvents(string, *GetOptions) ([]Event, *Response, error)
 	Ports(string, *GetOptions) ([]ConnectionPort, *Response, error)
 	Port(string, string, *GetOptions) (*ConnectionPort, *Response, error)
 	VirtualCircuits(string, string, *GetOptions) ([]ConnectionVirtualCircuit, *Response, error)
@@ -192,6 +194,16 @@ func (s *ConnectionServiceOp) Ports(connID string, opts *GetOptions) ([]Connecti
 
 func (s *ConnectionServiceOp) Events(id string, opts *GetOptions) ([]Event, *Response, error) {
 	apiPath := path.Join(connectionBasePath, id, eventBasePath)
+	return listEvents(s.client, apiPath, opts)
+}
+
+func (s *ConnectionServiceOp) PortEvents(connID, portID string, opts *GetOptions) ([]Event, *Response, error) {
+	apiPath := path.Join(connectionBasePath, connID, portBasePath, portID, eventBasePath)
+	return listEvents(s.client, apiPath, opts)
+}
+
+func (s *ConnectionServiceOp) VirtualCircuitEvents(id string, opts *GetOptions) ([]Event, *Response, error) {
+	apiPath := path.Join(virtualCircuitsBasePath, id, eventBasePath)
 	return listEvents(s.client, apiPath, opts)
 }
 

--- a/connections.go
+++ b/connections.go
@@ -6,13 +6,16 @@ import (
 
 type ConnectionRedundancy string
 type ConnectionType string
+type ConnectionPortRole string
 
 const (
-	connectionBasePath                       = "/connections"
-	ConnectionShared    ConnectionType       = "shared"
-	ConnectionDedicated ConnectionType       = "dedicated"
-	ConnectionRedundant ConnectionRedundancy = "redundant"
-	ConnectionPrimary   ConnectionRedundancy = "primary"
+	connectionBasePath                           = "/connections"
+	ConnectionShared        ConnectionType       = "shared"
+	ConnectionDedicated     ConnectionType       = "dedicated"
+	ConnectionRedundant     ConnectionRedundancy = "redundant"
+	ConnectionPrimary       ConnectionRedundancy = "primary"
+	ConnectionPortPrimary   ConnectionPortRole   = "primary"
+	ConnectionPortSecondary ConnectionPortRole   = "secondary"
 )
 
 type ConnectionService interface {
@@ -43,15 +46,15 @@ type connectionsRoot struct {
 }
 
 type ConnectionPort struct {
-	ID              string           `json:"id"`
-	Name            string           `json:"name,omitempty"`
-	Status          string           `json:"status,omitempty"`
-	Role            string           `json:"role,omitempty"`
-	Speed           int              `json:"speed,omitempty"`
-	Organization    *Organization    `json:"organization,omitempty"`
-	VirtualCircuits []VirtualCircuit `json:"virtual_circuits,omitempty"`
-	LinkStatus      string           `json:"link_status,omitempty"`
-	Href            string           `json:"href,omitempty"`
+	ID              string             `json:"id"`
+	Name            string             `json:"name,omitempty"`
+	Status          string             `json:"status,omitempty"`
+	Role            ConnectionPortRole `json:"role,omitempty"`
+	Speed           int                `json:"speed,omitempty"`
+	Organization    *Organization      `json:"organization,omitempty"`
+	VirtualCircuits []VirtualCircuit   `json:"virtual_circuits,omitempty"`
+	LinkStatus      string             `json:"link_status,omitempty"`
+	Href            string             `json:"href,omitempty"`
 }
 
 type Connection struct {
@@ -79,6 +82,15 @@ type ConnectionCreateRequest struct {
 	Project     string               `json:"project,omitempty"`
 	Speed       int                  `json:"speed,omitempty"`
 	Tags        []string             `json:"tags,omitempty"`
+}
+
+func (c *Connection) PortByRole(r ConnectionPortRole) *ConnectionPort {
+	for _, p := range c.Ports {
+		if p.Role == r {
+			return &p
+		}
+	}
+	return nil
 }
 
 func (s *ConnectionServiceOp) create(apiUrl string, createRequest *ConnectionCreateRequest) (*Connection, *Response, error) {

--- a/connections_test.go
+++ b/connections_test.go
@@ -65,11 +65,11 @@ func TestAccConnectionProject(t *testing.T) {
 	}
 
 	if len(vcs) > 0 {
-		vc, _, err := c.Connections.VirtualCircuit(vcs[0].ID, nil)
+		vc, _, err := c.VirtualCircuits.Get(vcs[0].ID, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, _, err = c.Connections.VirtualCircuitEvents(vc.ID, nil)
+		_, _, err = c.VirtualCircuits.Events(vc.ID, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/connections_test.go
+++ b/connections_test.go
@@ -26,7 +26,7 @@ func TestAccConnectionProject(t *testing.T) {
 
 	createdConnID := conn.ID
 
-	log.Printf("%#v\n", conn)
+	log.Printf("Test Connection:\n%#v\n", conn)
 
 	conn, _, err = c.Connections.Get(conn.ID, nil)
 	if err != nil {
@@ -54,18 +54,25 @@ func TestAccConnectionProject(t *testing.T) {
 		t.Fatalf("Mismatch when getting Conenction Port, ID should be %s, was %s", ports[0].ID, port.ID)
 	}
 
+	_, _, err = c.Connections.PortEvents(conn.ID, port.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	vcs, _, err := c.Connections.VirtualCircuits(conn.ID, port.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Printf("%#v\n", vcs)
 
 	if len(vcs) > 0 {
 		vc, _, err := c.Connections.VirtualCircuit(vcs[0].ID, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		log.Printf("VC::: %#v\n", vc)
+		_, _, err = c.Connections.VirtualCircuitEvents(vc.ID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 		/*
 			        fails with "Virtual Circuits on shared connections may not be deleted."
 					_, err = c.Connections.DeleteVirtualCircuit(vc.ID)

--- a/connections_test.go
+++ b/connections_test.go
@@ -1,0 +1,56 @@
+package packngo
+
+import (
+	"log"
+	"testing"
+)
+
+func TestAccConnectionProject(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	t.Parallel()
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+
+	connReq := ConnectionCreateRequest{
+		Name:       "testconn",
+		Redundancy: "test",
+		Facility:   "ewr1",
+		Type:       "testtype",
+	}
+
+	log.Println("hear")
+
+	conn, _, err := c.Connections.ProjectCreate(projectID, &connReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("%#v", conn)
+}
+
+func TestAccConnectionOrganization(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	t.Parallel()
+	c, stopRecord := setup(t)
+	defer stopRecord()
+
+	connReq := ConnectionCreateRequest{
+		Name:       "testconn",
+		Redundancy: "test",
+		Facility:   "ewr1",
+		Type:       "testtype",
+	}
+
+	user, _, err := c.Users.Current()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, _, err := c.Connections.OrganizationCreate(user.DefaultOrganizationID, &connReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("%#v", conn)
+}

--- a/packngo.go
+++ b/packngo.go
@@ -125,6 +125,7 @@ type Client struct {
 	TwoFactorAuth          TwoFactorAuthService
 	Users                  UserService
 	VPN                    VPNService
+	VirtualCircuits        VirtualCircuitService
 	VolumeAttachments      VolumeAttachmentService
 	Volumes                VolumeService
 }
@@ -372,6 +373,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.SpotMarketRequests = &SpotMarketRequestServiceOp{client: c}
 	c.TwoFactorAuth = &TwoFactorAuthServiceOp{client: c}
 	c.Users = &UserServiceOp{client: c}
+	c.VirtualCircuits = &VirtualCircuitServiceOp{client: c}
 	c.VPN = &VPNServiceOp{client: c}
 	c.VolumeAttachments = &VolumeAttachmentServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}

--- a/packngo.go
+++ b/packngo.go
@@ -104,6 +104,7 @@ type Client struct {
 	BGPSessions            BGPSessionService
 	Batches                BatchService
 	CapacityService        CapacityService
+	Connections            ConnectionService
 	DeviceIPs              DeviceIPService
 	DevicePorts            DevicePortService
 	Devices                DeviceService
@@ -351,6 +352,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.BGPSessions = &BGPSessionServiceOp{client: c}
 	c.Batches = &BatchServiceOp{client: c}
 	c.CapacityService = &CapacityServiceOp{client: c}
+	c.Connections = &ConnectionServiceOp{client: c}
 	c.DeviceIPs = &DeviceIPServiceOp{client: c}
 	c.DevicePorts = &DevicePortServiceOp{client: c}
 	c.Devices = &DeviceServiceOp{client: c}

--- a/virtualcircuits.go
+++ b/virtualcircuits.go
@@ -17,8 +17,7 @@ type VirtualCircuitService interface {
 	Get(string, *GetOptions) (*VirtualCircuit, *Response, error)
 	Events(string, *GetOptions) ([]Event, *Response, error)
 	Delete(string) (*Response, error)
-	ConnectVLAN(string, string, *GetOptions) (*VirtualCircuit, *Response, error)
-	RemoveVLAN(string, *GetOptions) (*VirtualCircuit, *Response, error)
+	Update(string, *VCUpdateRequest, *GetOptions) (*VirtualCircuit, *Response, error)
 }
 
 type VCUpdateRequest struct {
@@ -61,18 +60,10 @@ func (s *VirtualCircuitServiceOp) do(method, apiPathQuery string, req interface{
 
 }
 
-func (s *VirtualCircuitServiceOp) ConnectVLAN(vcID, vlanID string, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+func (s *VirtualCircuitServiceOp) Update(vcID string, req *VCUpdateRequest, opts *GetOptions) (*VirtualCircuit, *Response, error) {
 	endpointPath := path.Join(virtualCircuitBasePath, vcID)
 	apiPathQuery := opts.WithQuery(endpointPath)
-	updateReq := VCUpdateRequest{VirtualNetworkID: &vlanID}
-	return s.do("PUT", apiPathQuery, updateReq)
-}
-
-func (s *VirtualCircuitServiceOp) RemoveVLAN(vcID string, opts *GetOptions) (*VirtualCircuit, *Response, error) {
-	endpointPath := path.Join(virtualCircuitBasePath, vcID)
-	apiPathQuery := opts.WithQuery(endpointPath)
-	updateReq := VCUpdateRequest{VirtualNetworkID: nil}
-	return s.do("PUT", apiPathQuery, updateReq)
+	return s.do("PUT", apiPathQuery, req)
 }
 
 func (s *VirtualCircuitServiceOp) Events(id string, opts *GetOptions) ([]Event, *Response, error) {

--- a/virtualcircuits.go
+++ b/virtualcircuits.go
@@ -57,7 +57,6 @@ func (s *VirtualCircuitServiceOp) do(method, apiPathQuery string, req interface{
 		return nil, resp, err
 	}
 	return vc, resp, err
-
 }
 
 func (s *VirtualCircuitServiceOp) Update(vcID string, req *VCUpdateRequest, opts *GetOptions) (*VirtualCircuit, *Response, error) {

--- a/virtualcircuits.go
+++ b/virtualcircuits.go
@@ -1,0 +1,88 @@
+package packngo
+
+import "path"
+
+const (
+	virtualCircuitBasePath = "/virtual-circuits"
+	vcStatusActive         = "active"
+	vcStatusWaiting        = "waiting_on_customer_vlan"
+	//vcStatusActivating     = "activating"
+	//vcStatusDeactivating   = "deactivating"
+)
+
+type VirtualCircuitService interface {
+	Get(string, *GetOptions) (*VirtualCircuit, *Response, error)
+	Events(string, *GetOptions) ([]Event, *Response, error)
+	Delete(string) (*Response, error)
+	ConnectVLAN(string, string, *GetOptions) (*VirtualCircuit, *Response, error)
+	RemoveVLAN(string, *GetOptions) (*VirtualCircuit, *Response, error)
+}
+
+type VCUpdateRequest struct {
+	VirtualNetworkID *string `json:"vnid"`
+}
+
+type VirtualCircuitServiceOp struct {
+	client *Client
+}
+
+type virtualCircuitsRoot struct {
+	VirtualCircuits []VirtualCircuit `json:"virtual_circuits"`
+	Meta            meta             `json:"meta"`
+}
+
+type VirtualCircuit struct {
+	ID             string          `json:"id"`
+	Name           string          `json:"name,omitempty"`
+	Status         string          `json:"status,omitempty"`
+	VNID           int             `json:"vnid,omitempty"`
+	NniVNID        int             `json:"nni_vnid,omitempty"`
+	NniVLAN        int             `json:"nni_vlan,omitempty"`
+	Project        *Project        `json:"project,omitempty"`
+	VirtualNetwork *VirtualNetwork `json:"virtual_network,omitempty"`
+}
+
+func (s *VirtualCircuitServiceOp) ConnectVLAN(vcID, vlanID string, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+	endpointPath := path.Join(virtualCircuitBasePath, vcID)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	vc := new(VirtualCircuit)
+	updateReq := VCUpdateRequest{VirtualNetworkID: &vlanID}
+	resp, err := s.client.DoRequest("PUT", apiPathQuery, updateReq, vc)
+	if err != nil {
+		return nil, resp, err
+	}
+	return vc, resp, err
+}
+
+func (s *VirtualCircuitServiceOp) RemoveVLAN(vcID string, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+	endpointPath := path.Join(virtualCircuitBasePath, vcID)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	vc := new(VirtualCircuit)
+	updateReq := VCUpdateRequest{VirtualNetworkID: nil}
+	resp, err := s.client.DoRequest("PUT", apiPathQuery, updateReq, vc)
+	if err != nil {
+		return nil, resp, err
+	}
+	return vc, resp, err
+}
+
+func (s *VirtualCircuitServiceOp) Events(id string, opts *GetOptions) ([]Event, *Response, error) {
+	apiPath := path.Join(virtualCircuitBasePath, id, eventBasePath)
+	return listEvents(s.client, apiPath, opts)
+}
+
+func (s *VirtualCircuitServiceOp) Get(id string, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+	endpointPath := path.Join(virtualCircuitBasePath, id)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	vc := new(VirtualCircuit)
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, vc)
+	if err != nil {
+		return nil, resp, err
+	}
+	return vc, resp, err
+}
+
+func (s *VirtualCircuitServiceOp) Delete(id string) (*Response, error) {
+	apiPath := path.Join(virtualCircuitBasePath, id)
+	return s.client.DoRequest("DELETE", apiPath, nil, nil)
+}

--- a/virtualcircuits.go
+++ b/virtualcircuits.go
@@ -3,11 +3,11 @@ package packngo
 import "path"
 
 const (
-	virtualCircuitBasePath     = "/virtual-circuits"
-	vcStatusActive             = "active"
-	vcStatusWaiting            = "waiting_on_customer_vlan"
-	vcStatusActivating         = "activating"
-	vcStatusDeactivating       = "deactivating"
+	virtualCircuitBasePath = "/virtual-circuits"
+	vcStatusActive         = "active"
+	vcStatusWaiting        = "waiting_on_customer_vlan"
+	//vcStatusActivating         = "activating"
+	//vcStatusDeactivating       = "deactivating"
 	vcStatusActivationFailed   = "activation_failed"
 	vcStatusDeactivationFailed = "dactivation_failed"
 )

--- a/virtualcircuits_test.go
+++ b/virtualcircuits_test.go
@@ -15,6 +15,13 @@ func removeVirtualNetwork(t *testing.T, c *Client, id string) {
 	}
 }
 
+func removeVirtualCircuit(t *testing.T, c *Client, id string) {
+	_, err := c.VirtualCircuits.Delete(id)
+	if err != nil {
+		t.Log("Err when removing testing VirtualCircuit:", err)
+	}
+}
+
 func waitVirtualCircuitStatus(t *testing.T, c *Client, id, status string, errStati []string) (*VirtualCircuit, error) {
 	// 15 minutes = 180 * 5sec-retry
 	for i := 0; i < 180; i++ {
@@ -87,7 +94,7 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.VirtualCircuits.Delete(vc.ID)
+	defer removeVirtualCircuit(t, c, vc.ID)
 
 	_, err = waitVirtualCircuitStatus(t, c, vc.ID, vcStatusActive,
 		[]string{vcStatusActivationFailed})
@@ -106,7 +113,7 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer c.VirtualCircuits.Delete(vc2.ID)
+	defer removeVirtualCircuit(t, c, vc2.ID)
 
 	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, vcStatusActive,
 		[]string{vcStatusActivationFailed})

--- a/virtualcircuits_test.go
+++ b/virtualcircuits_test.go
@@ -1,0 +1,104 @@
+package packngo
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func waitVirtualCircuitStatus(t *testing.T, c *Client, id, status string) *VirtualCircuit {
+	// 15 minutes = 180 * 5sec-retry
+	for i := 0; i < 180; i++ {
+		<-time.After(5 * time.Second)
+		vc, _, err := c.VirtualCircuits.Get(id, nil)
+		if err != nil {
+			t.Fatal(err)
+			return nil
+		}
+		if vc.Status == status {
+			return vc
+		}
+	}
+	t.Fatal(fmt.Errorf("Virtual Circuit %s is still not %s after timeout", id, status))
+	return nil
+}
+
+// this test needs an existing Shared Connection. Pass the ID in env var
+// "PACKNGO_TEST_CONNECTION"
+func TestAccVirtualCircuitShared(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	c, stopRecord := setup(t)
+	defer stopRecord()
+	testConnectionEnvVar := "PACKNGO_TEST_CONNECTION"
+
+	cid := os.Getenv(testConnectionEnvVar)
+	if cid == "" {
+		t.Skipf("%s is not set", testConnectionEnvVar)
+	}
+
+	conn, _, err := c.Connections.Get(cid, &GetOptions{Includes: []string{"facility"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vc, _, err := c.VirtualCircuits.Get(conn.Ports[0].VirtualCircuits[0].ID,
+		&GetOptions{Includes: []string{"project"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vc.Status == vcStatusActive {
+		vc, _, err = c.VirtualCircuits.RemoveVLAN(vc.ID, &GetOptions{Includes: []string{"project"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		waitVirtualCircuitStatus(t, c, vc.ID, vcStatusWaiting)
+	}
+
+	fac := conn.Facility.Code
+	projectID := vc.Project.ID
+
+	cr := VirtualNetworkCreateRequest{
+		ProjectID:   projectID,
+		Description: "VLAN for VirtualCircuiti test",
+		Facility:    fac,
+	}
+
+	vlan, _, err := c.ProjectVirtualNetworks.Create(&cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, err := c.ProjectVirtualNetworks.Delete(vlan.ID)
+		if err != nil {
+			t.Log("Err when removing testing VLAN:", err)
+		}
+	}()
+
+	vc, _, err = c.VirtualCircuits.ConnectVLAN(vc.ID, vlan.ID,
+		&GetOptions{Includes: []string{"virtual_network"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitVirtualCircuitStatus(t, c, vc.ID, vcStatusActive)
+
+	vc, _, err = c.VirtualCircuits.Get(vc.ID,
+		&GetOptions{Includes: []string{"virtual_network,project"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vc.VirtualNetwork.ID != vlan.ID {
+		t.Fatalf("ID of assigned vlan from the virtual circuit should be %s, was %s",
+			vlan.ID, vc.VirtualNetwork.ID)
+	}
+
+	if vc.VNID != vlan.VXLAN {
+		t.Fatalf("Numerical ID of assigned vlan from the virtual circuit should be %d, was %d",
+			vlan.VXLAN, vc.VNID)
+	}
+	_, _, err = c.VirtualCircuits.RemoveVLAN(vc.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}


### PR DESCRIPTION
This PR will add support for Connection API resource, fixes #228 

State of implemented API calls:

* [x] `POST ​/organizations​/{organization_id}​/connections` Request a new connection for the organization
* [x] `POST ​/projects​/{project_id}​/connections` Request a new connection for the project's organization
* [x] `GET ​/organizations​/{organization_id}​/connections` List organization connections
* [x] `GET ​/projects​/{project_id}​/connections` List project connections
* [x] `GET ​/connections​/{id}` Get connection
* [ ] `PUT ​/connections​/{id}` Update connection
* [x] `DELETE ​/connections​/{id}` Delete connection
* [x] `GET ​/connections​/{id}​/events` Retrieve connection events
* [x] `GET ​/connections​/{id}​/ports​/{id}​/events` Retrieve connection port events
* [x] `GET ​/virtual-circuit​/{id}​/events` Retrieve connection events
* [x] `GET ​/connections​/{connection_id}​/ports` List a connection's ports
* [x] `GET ​/connections​/{connection_id}​/ports​/{id}` Get a connection port
* [x] `GET ​/connections​/{connection_id}​/ports​/{port_id}​/virtual-circuits` List a connection port's virtual circuits
* [x] `POST ​/connections​/{connection_id}​/ports​/{port_id}​/virtual-circuits` Create a new Virtual Circuit
* [x] `GET ​/virtual-circuits​/{id}` Get a virtual circuit
* [x] `PUT ​/virtual-circuits​/{id}` Update a virtual circuit
* [x] `DELETE ​/virtual-circuits​/{id}` Delete a virtual circuit

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>