### PR TITLE
Support for network types per bond, and for the new hybrid-bonded type

### DIFF
--- a/bond_ports.go
+++ b/bond_ports.go
@@ -45,7 +45,7 @@ func (i *DevicePortServiceOp) BondToNetworkType(deviceID, bondPortName, targetTy
 	curType := d.GetBondNetworkType(bondPortName)
 
 	if !BondStateTransitionNecessary(curType, targetType) {
-		return nil, fmt.Errorf("Bond doesn't need to be converted from %s to %s", curType, targetType)
+		return d, nil
 	}
 
 	err = i.ConvertDeviceBond(d, bondPortName, targetType)

--- a/bond_ports.go
+++ b/bond_ports.go
@@ -1,0 +1,159 @@
+package packngo
+
+import "fmt"
+
+const NetworkTypeHybridBonded = "hybrid-bonded"
+
+func (d *Device) GetBondNetworkType(portName string) string {
+	for _, p := range d.NetworkPorts {
+		if p.Name == portName {
+			return p.NetworkType
+		}
+	}
+	return ""
+}
+
+func (d *Device) GetEthPortsInBond(name string) []*Port {
+	ports := []*Port{}
+	for _, port := range d.NetworkPorts {
+		if port.Bond != nil && port.Bond.Name == name {
+			ports = append(ports, &port)
+		}
+	}
+	return ports
+}
+
+func BondStateTransitionNecessary(type1, type2 string) bool {
+	if type1 == type2 {
+		return false
+	}
+	if type1 == NetworkTypeHybridBonded && type2 == NetworkTypeL3 {
+		return false
+	}
+	if type2 == NetworkTypeHybridBonded && type1 == NetworkTypeL3 {
+		return false
+	}
+	return true
+}
+
+func (i *DevicePortServiceOp) BondToNetworkType(deviceID, bondPortName, targetType string) (*Device, error) {
+	d, _, err := i.client.Devices.Get(deviceID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	curType := d.GetBondNetworkType(bondPortName)
+
+	if !BondStateTransitionNecessary(curType, targetType) {
+		return nil, fmt.Errorf("Bond doesn't need to be converted from %s to %s", curType, targetType)
+	}
+
+	err = i.ConvertDeviceBond(d, bondPortName, targetType)
+	if err != nil {
+		return nil, err
+	}
+
+	d, _, err = i.client.Devices.Get(deviceID, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	finalType := d.GetNetworkType()
+
+	if BondStateTransitionNecessary(finalType, targetType) {
+		return nil, fmt.Errorf(
+			"Failed to convert %s on device %s from %s to %s. New type was %s",
+			bondPortName, deviceID, curType, targetType, finalType)
+
+	}
+	return d, err
+}
+
+func (i *DevicePortServiceOp) ConvertDeviceBond(d *Device, bondPortName, targetType string) error {
+	bondPort, err := d.GetPortByName(bondPortName)
+	if err != nil {
+		return err
+	}
+
+	if targetType == NetworkTypeL3 || targetType == NetworkTypeHybridBonded {
+		_, _, err := i.Bond(bondPort, false)
+		if err != nil {
+			return err
+		}
+		_, _, err = i.PortToLayerThree(d.ID, bondPortName)
+		if err != nil {
+			return err
+		}
+		// device needs to be refreshed, the bond and convert calls might bond eths
+		d, _, err := i.client.Devices.Get(d.ID, nil)
+		if err != nil {
+			return err
+		}
+		for _, p := range d.GetEthPortsInBond(bondPortName) {
+			_, _, err := i.Bond(p, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if targetType == NetworkTypeHybrid {
+		_, _, err := i.Bond(bondPort, false)
+		if err != nil {
+			return err
+		}
+		_, _, err = i.PortToLayerThree(d.ID, bondPortName)
+		if err != nil {
+			return err
+		}
+
+		// device needs to be refreshed, the bond and convert calls might bond eths
+		d, _, err := i.client.Devices.Get(d.ID, nil)
+		if err != nil {
+			return err
+		}
+		ethLatter := d.GetEthPortsInBond(bondPortName)[1]
+
+		_, _, err = i.Disbond(ethLatter, false)
+		if err != nil {
+			return err
+		}
+	}
+	if targetType == NetworkTypeL2Individual {
+		_, _, err := i.PortToLayerTwo(d.ID, bondPortName)
+		if err != nil {
+			return err
+		}
+		// device needs to be refreshed, the convert call might break the bond
+		d, _, err := i.client.Devices.Get(d.ID, nil)
+		if err != nil {
+			return err
+		}
+		bondPort, err := d.GetPortByName(bondPortName)
+		if err != nil {
+			return err
+		}
+		_, _, err = i.Disbond(bondPort, true)
+		if err != nil {
+			return err
+		}
+	}
+	if targetType == NetworkTypeL2Bonded {
+		_, _, err := i.PortToLayerTwo(d.ID, bondPortName)
+		if err != nil {
+			return err
+		}
+		// device needs to be refreshed, the convert call might break the bond
+		d, _, err := i.client.Devices.Get(d.ID, nil)
+		if err != nil {
+			return err
+		}
+		for _, p := range d.GetEthPortsInBond(bondPortName) {
+			_, _, err := i.Bond(p, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/bond_ports_test.go
+++ b/bond_ports_test.go
@@ -1,0 +1,137 @@
+package packngo
+
+import (
+	"log"
+	"testing"
+	"time"
+)
+
+func deviceBondToNetworkType(t *testing.T, c *Client, deviceID, bondPortName, targetNetworkType string) {
+	d, _, err := c.Devices.Get(deviceID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldType := d.GetBondNetworkType(bondPortName)
+	log.Println("Converting", bondPortName, oldType, "=>", targetNetworkType, "...")
+	_, err = c.DevicePorts.BondToNetworkType(deviceID, bondPortName, targetNetworkType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Println(oldType, "=>", targetNetworkType, "OK")
+	// why sleep here??
+	time.Sleep(5 * time.Second)
+}
+
+func TestAccPortBondNetworkStateTransitions(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	t.Parallel()
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+
+	fac := testFacility()
+
+	cr := DeviceCreateRequest{
+		Hostname:     "bondNetworkTypeTest",
+		Facility:     []string{fac},
+		Plan:         "c3.small.x86",
+		OS:           testOS,
+		ProjectID:    projectID,
+		BillingCycle: "hourly",
+	}
+	d, _, err := c.Devices.Create(&cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleteDevice(t, c, d.ID, false)
+	deviceID := d.ID
+
+	d = waitDeviceActive(t, c, deviceID)
+
+	bond := "bond0"
+
+	networkType := d.GetBondNetworkType(bond)
+	if networkType != NetworkTypeL3 {
+		t.Fatal("network_type should be 'layer3'")
+	}
+
+	if networkType != NetworkTypeL2Bonded {
+		deviceBondToNetworkType(t, c, deviceID, bond, NetworkTypeL2Bonded)
+	}
+
+	deviceBondToNetworkType(t, c, deviceID, bond, NetworkTypeL2Individual)
+}
+
+func TestAccPortBondNetworkStateHybridBonded(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	t.Parallel()
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+
+	fac := testFacility()
+
+	cr := DeviceCreateRequest{
+		Hostname:     "NetworkTypeHybridBondedTest",
+		Facility:     []string{fac},
+		Plan:         "c3.small.x86",
+		OS:           testOS,
+		ProjectID:    projectID,
+		BillingCycle: "hourly",
+	}
+	d, _, err := c.Devices.Create(&cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleteDevice(t, c, d.ID, false)
+	deviceID := d.ID
+
+	d = waitDeviceActive(t, c, deviceID)
+
+	bond := "bond0"
+
+	networkType := d.GetBondNetworkType(bond)
+	if networkType != NetworkTypeL3 {
+		t.Fatal("network_type should be 'layer3'")
+	}
+
+	testDesc := "test_desc_" + randString8()
+
+	vncr := VirtualNetworkCreateRequest{
+		ProjectID:   projectID,
+		Description: testDesc,
+		Facility:    testFacility(),
+	}
+
+	vlan, _, err := c.ProjectVirtualNetworks.Create(&vncr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleteProjectVirtualNetwork(t, c, vlan.ID)
+
+	bondPort, _ := d.GetPortByName(bond)
+
+	par := PortAssignRequest{
+		PortID:           bondPort.ID,
+		VirtualNetworkID: vlan.ID}
+
+	p, _, err := c.DevicePorts.Assign(&par)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("%#v\n", p)
+
+	d, _, err = c.Devices.Get(d.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newBondNetworkType := d.GetBondNetworkType(bond)
+	if newBondNetworkType != NetworkTypeHybridBonded {
+		t.Fatalf("After bond0 is in L3 and VLAN is assigned to bond0, it's network type should be %s. Was %s", NetworkTypeHybridBonded, newBondNetworkType)
+	}
+
+	_, _, err = c.DevicePorts.Unassign(&par)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/ports.go
+++ b/ports.go
@@ -24,6 +24,8 @@ type DevicePortService interface {
 	GetOddEthPorts(*Device) (map[string]*Port, error)
 	GetAllEthPorts(*Device) (map[string]*Port, error)
 	ConvertDevice(*Device, string) error
+	BondToNetworkType(string, string, string) (*Device, error)
+	ConvertDeviceBond(*Device, string, string) error
 }
 
 type PortData struct {


### PR DESCRIPTION
Fixes #231

@displague will probably not be happy about the format of this PR, but I think this is the best way to add support for network type per bond (like it's in the UI), and for the hybrid-bonded network type.

I initally wanted to create a separate netwokr type transitions for the hybrid-bonded, but I realized it's very hard to do well. The hybrid-mixed type is reported when we assign a VLAN to a layer3 bond port of a device (of certain plans). The assigned VLAN is the only difference between layer3 and hybrid-bonded types. I think it's best to merge those two types, and leave the VLAN assignment up to the user.

If we assume a VLAN ID as a part of the network type hybrid-bonded, we would need to keep track of the assigned VLAN, and remove it once it's converted to some other network type. Problem is, that user can assign more vlans to the bond port later on. This is not hard to sanitize in the Golang SDK, but it would be disturbing for new terraform resource `device_bond_network_type`. If a user will assign VLANs explicitly in other resources, the `device_bond_network_type` will not be importable, because we can't say which was the VLAN that put it to the hybrid-bonded type. We will also need to store the inital VLAN id locally.

If we (sort of) merge the l3 and h-bonded types, we can achieve all that is possible in the UI, and we have a good chance to make the bond network state controllable in Terraform.

I put the new code intentionaly to new files, so that it can be reviewed easier.

Putting a device to hybrid-mixed network type is illustrated in `TestAccPortBondNetworkStateHybridBonded`. You should run the test in some faciltiy where c3.small.x86 is available, e.g.
```
PACKNGO_TEST_FACILITY=ny5 PACKNGO_DEBUG=1 PACKNGO_TEST_ACTUAL_API=1 go test -v -timeout=20m -run=TestAccPortBondNetworkStateHybridBonded
```