### PR TITLE
remove retry policy function used by removed retryablehttp client

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -32,8 +32,6 @@ const (
 	expectedAPIContentTypePrefix = "application/json"
 )
 
-var redirectsErrorRe = regexp.MustCompile(`stopped after \d+ redirects\z`)
-
 // meta contains pagination information
 type meta struct {
 	Self           *Href `json:"self"`

--- a/packngo.go
+++ b/packngo.go
@@ -3,7 +3,6 @@ package packngo
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -299,45 +298,6 @@ func NewClient() (*Client, error) {
 func NewClientWithAuth(consumerToken string, apiKey string, httpClient *http.Client) *Client {
 	client, _ := NewClientWithBaseURL(consumerToken, apiKey, httpClient, baseURL)
 	return client
-}
-
-// RetryPolicy determines if the supplied http Response and error can be safely
-// retried (for use with github.com/hashicorp/go-retryablehttp clients)
-//
-//    retryClient := retryablehttp.NewClient()
-//    retryClient.CheckRetry = packngo.RetryPolicy
-func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	// do not retry on context.Canceled or context.DeadlineExceeded
-	if ctx.Err() != nil {
-		return false, ctx.Err()
-	}
-
-	if err != nil {
-		if v, ok := err.(*url.Error); ok {
-			// Don't retry if the error was due to too many redirects.
-			if redirectsErrorRe.MatchString(v.Error()) {
-				return false, nil
-			}
-
-			// Don't retry if the error was due to TLS cert verification failure.
-			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
-				return false, nil
-			}
-		}
-
-		// The error is likely recoverable so retry.
-		return true, nil
-	}
-
-	// Check the response code. We retry on 500-range responses to allow
-	// the server time to recover, as 500's are typically not permanent
-	// errors and may relate to outages on the server side. This will catch
-	// invalid response codes as well, like 0 and 999.
-	//if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != 501) {
-	//	return true, nil
-	//}
-
-	return false, nil
 }
 
 // NewClientWithBaseURL returns a Client pointing to nonstandard API URL, e.g.


### PR DESCRIPTION
Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>

Fixes #237