### PR TITLE
deprecate VPN (Doorman) services, endpoints, configs, and properties

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -121,7 +121,6 @@ type Client struct {
 	SpotMarketRequests     SpotMarketRequestService
 	TwoFactorAuth          TwoFactorAuthService
 	Users                  UserService
-	VPN                    VPNService
 	VirtualCircuits        VirtualCircuitService
 	VolumeAttachments      VolumeAttachmentService
 	Volumes                VolumeService
@@ -130,6 +129,13 @@ type Client struct {
 	//
 	// Deprecated: Use Client.Ports or Device methods
 	DevicePorts DevicePortService
+
+	// VPN
+	//
+	// Deprecated: As of March 31, 2021, Doorman service is no longer
+	// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+	// for more details.
+	VPN VPNService
 }
 
 // requestDoer provides methods for making HTTP requests and receiving the

--- a/user.go
+++ b/user.go
@@ -36,7 +36,13 @@ type User struct {
 	Emails                []Email `json:"emails,omitempty"`
 	PhoneNumber           string  `json:"phone_number,omitempty"`
 	URL                   string  `json:"href,omitempty"`
-	VPN                   bool    `json:"vpn"`
+
+	// VPN indicates if Doorman VPN service is enabled for the user.
+	//
+	// Deprecated: As of March 31, 2021, Doorman service is no longer
+	// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+	// for more details.
+	VPN bool `json:"vpn"`
 }
 
 func (u User) String() string {

--- a/vpn.go
+++ b/vpn.go
@@ -5,11 +5,19 @@ import "fmt"
 const vpnBasePath = "/user/vpn"
 
 // VPNConfig struct
+//
+// Deprecated: As of March 31, 2021, Doorman service is no longer
+// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+// for more details.
 type VPNConfig struct {
 	Config string `json:"config,omitempty"`
 }
 
 // VPNService interface defines available VPN functions
+//
+// Deprecated: As of March 31, 2021, Doorman service is no longer
+// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+// for more details.
 type VPNService interface {
 	Enable() (*Response, error)
 	Disable() (*Response, error)
@@ -17,22 +25,38 @@ type VPNService interface {
 }
 
 // VPNServiceOp implements VPNService
+//
+// Deprecated: As of March 31, 2021, Doorman service is no longer
+// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+// for more details.
 type VPNServiceOp struct {
 	client *Client
 }
 
 // Enable VPN for current user
+//
+// Deprecated: As of March 31, 2021, Doorman service is no longer
+// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+// for more details.
 func (s *VPNServiceOp) Enable() (resp *Response, err error) {
 	return s.client.DoRequest("POST", vpnBasePath, nil, nil)
 }
 
 // Disable VPN for current user
+//
+// Deprecated: As of March 31, 2021, Doorman service is no longer
+// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+// for more details.
 func (s *VPNServiceOp) Disable() (resp *Response, err error) {
 	return s.client.DoRequest("DELETE", vpnBasePath, nil, nil)
 
 }
 
 // Get returns the client vpn config for the currently logged-in user.
+//
+// Deprecated: As of March 31, 2021, Doorman service is no longer
+// available. See https://metal.equinix.com/developers/docs/accounts/doorman/
+// for more details.
 func (s *VPNServiceOp) Get(code string, opts *GetOptions) (config *VPNConfig, resp *Response, err error) {
 	params := urlQuery(opts)
 	config = &VPNConfig{}


### PR DESCRIPTION
Doorman service is deprecated and will be removed from the API and disabled for new and existing users.

See https://metal.equinix.com/developers/docs/accounts/doorman/

Signed-off-by: Marques Johansson <mjohansson@equinix.com>