### PR TITLE
fix missed library version bump, now 0.7.1

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	authTokenEnvVar = "PACKET_AUTH_TOKEN"
-	libraryVersion  = "0.6.0"
+	libraryVersion  = "0.7.1"
 	baseURL         = "https://api.equinix.com/metal/v1/"
 	userAgent       = "packngo/" + libraryVersion
 	mediaType       = "application/json"


### PR DESCRIPTION
I missed the version bump in the previous release, now pushing the version to 0.7.1 for the next release.