### PR TITLE
v0.8.0 version bump

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,29 +20,29 @@ they can be run in the absence of that automation.
   git branch --points-at=master -r  | grep origin/master >/dev/null || echo "master differs from origin/master"
   ```
 
-* Update the `libraryVersion` constant. This is a library, so we can not assure
+* Update the `Version` variable. This is a library, so we can not assure
   that a build flag will be used in every client that provides a compile time
   value, let alone the correct one.
 
   ```sh
-  vim packngo.go # change libraryVersion, "0.3.0" (no v)
-  git commit --signoff -m 'v0.3.0 version bump' packngo.go
+  vim version.go # change Version, "0.8.0" (no v)
+  git commit --signoff -m 'v0.8.0 version bump' packngo.go
   ```
 
 * Tag `master` with a semver tag that suits the level of changes
   introduced:
 
   ```sh
-  git tag -m "v0.3.0" -a v0.3.0 master # use -s if gpg is available
+  git tag -m "v0.8.0" -a v0.8.0 master # use -s if gpg is available
   ```
 * Push the tag:
 
   ```sh
-  git push --tags origin master v0.3.0
+  git push --tags origin master v0.8.0
   ```
 * Create a release from the tag (include a keepthechangelog.com formatted description):
 
-  <https://github.com/packethost/packngo/releases/edit/v0.3.0> (use the correct
+  <https://github.com/packethost/packngo/releases/edit/v0.8.0> (use the correct
   version)
 
 Releases can be followed through the GitHub Atom feed at

--- a/packngo.go
+++ b/packngo.go
@@ -20,9 +20,7 @@ import (
 
 const (
 	authTokenEnvVar = "PACKET_AUTH_TOKEN"
-	libraryVersion  = "0.7.1"
 	baseURL         = "https://api.equinix.com/metal/v1/"
-	userAgent       = "packngo/" + libraryVersion
 	mediaType       = "application/json"
 	debugEnvVar     = "PACKNGO_DEBUG"
 
@@ -30,6 +28,9 @@ const (
 	headerRateRemaining          = "X-RateLimit-Remaining"
 	headerRateReset              = "X-RateLimit-Reset"
 	expectedAPIContentTypePrefix = "application/json"
+
+	// UserAgent is the default HTTP User-Agent Header value that will be used by NewClient
+	UserAgent = "packngo/" + Version
 )
 
 // meta contains pagination information
@@ -317,7 +318,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 		return nil, err
 	}
 
-	c := &Client{client: httpClient, BaseURL: u, UserAgent: userAgent, ConsumerToken: consumerToken, APIKey: apiKey}
+	c := &Client{client: httpClient, BaseURL: u, UserAgent: UserAgent, ConsumerToken: consumerToken, APIKey: apiKey}
 	c.APIKeys = &APIKeyServiceOp{client: c}
 	c.BGPConfig = &BGPConfigServiceOp{client: c}
 	c.BGPSessions = &BGPSessionServiceOp{client: c}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package packngo
+
+// Version of the packngo package
+const Version = "0.8.0"


### PR DESCRIPTION
Makes Version and UserAgent public.
bump version to 0.8.0

Release notes will be:

```
v0.8.0

This version introduce support for the upcoming Metros feature #238. Either Metro or Facility should be used in requests that permit either field. This changelog will be updated with more details as they are made available.

## Features

* added Metro type
* added MetroService interface
* added MetroServiceOp type with List (fulfilling MetroService)
* added method CapacityService.ListMetros
* added method CapacityService.CheckMetros
* added field Client.Metros
* added field Plan.AvailableInMetros
* added field ServerInfo.Metro
* added field Connection.Metro
* added field ConnectionCreateRequest.Metro
* added field Device.Metro
* added field Facility.Metro
* added field DeviceCreateRequest.Metro
* added field IPAddressCommon.Metro
* added field IPReservationRequest.Metro
* added Version constant
* added UserAgent constant

## Changes

* DeviceCreateRequest.Facility is now omitted when empty