### PR TITLE
add VLAN support for metros

### DIFF
--- a/virtualnetworks.go
+++ b/virtualnetworks.go
@@ -16,13 +16,15 @@ type ProjectVirtualNetworkService interface {
 
 type VirtualNetwork struct {
 	ID           string    `json:"id"`
-	Description  string    `json:"description,omitempty"`
+	Description  string    `json:"description,omitempty"` // TODO: field can be null
 	VXLAN        int       `json:"vxlan,omitempty"`
 	FacilityCode string    `json:"facility_code,omitempty"`
+	MetroCode    string    `json:"metro_code,omitempty"`
 	CreatedAt    string    `json:"created_at,omitempty"`
 	Href         string    `json:"href"`
 	Project      *Project  `json:"assigned_to,omitempty"`
 	Facility     *Facility `json:"facility,omitempty"`
+	Metro        *Metro    `json:"metro,omitempty"`
 	Instances    []*Device `json:"instances,omitempty"`
 }
 
@@ -48,9 +50,22 @@ func (i *ProjectVirtualNetworkServiceOp) List(projectID string, opts *ListOption
 }
 
 type VirtualNetworkCreateRequest struct {
-	ProjectID   string `json:"project_id"`
+	// ProjectID of the project where the VLAN will be made available.
+	ProjectID string `json:"project_id"`
+
+	// Description is a user supplied description of the VLAN.
 	Description string `json:"description"`
-	Facility    string `json:"facility"`
+
+	// TODO: default Description is null when not specified. Permitting *string here would require changing VirtualNetwork.Description to *string too.
+
+	// Facility in which to create the VLAN. Mutually exclusive with Metro.
+	Facility string `json:"facility,omitempty"`
+
+	// Metro in which to create the VLAN. Mutually exclusive with Facility.
+	Metro string `json:"metro,omitempty"`
+
+	// VLAN ID may be specified when created in a metro. It is remotely incremented otherwise. Must be unique per Metro.
+	VLAN int `json:"vlan,omitempty"`
 }
 
 func (i *ProjectVirtualNetworkServiceOp) Get(vlanID string, opts *GetOptions) (*VirtualNetwork, *Response, error) {

--- a/virtualnetworks_test.go
+++ b/virtualnetworks_test.go
@@ -32,8 +32,6 @@ func TestAccVirtualNetworksFacility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer c.ProjectVirtualNetworks.Delete(vlan.ID)
-
 	vlan, _, err = c.ProjectVirtualNetworks.Get(vlan.ID,
 		&GetOptions{Includes: []string{"assigned_to", "facility"}})
 	if err != nil {
@@ -46,6 +44,11 @@ func TestAccVirtualNetworksFacility(t *testing.T) {
 
 	if vlan.Facility.Code != testFacility() {
 		t.Fatalf("Wrong Facility in test VLAN, should be %s, was %s", testFacility(), vlan.Facility.Code)
+	}
+
+	_, err = c.ProjectVirtualNetworks.Delete(vlan.ID)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -77,8 +80,6 @@ func TestAccVirtualNetworksMetro(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer c.ProjectVirtualNetworks.Delete(vlan.ID)
-
 	vlan, _, err = c.ProjectVirtualNetworks.Get(vlan.ID,
 		&GetOptions{Includes: []string{"assigned_to", "metro"}})
 	if err != nil {
@@ -91,6 +92,10 @@ func TestAccVirtualNetworksMetro(t *testing.T) {
 
 	if vlan.Metro.Code != testMetro() {
 		t.Fatalf("Wrong metro for testing VLAN, should be %s, was %s", testMetro(), vlan.Metro.Code)
+	}
+	_, err = c.ProjectVirtualNetworks.Delete(vlan.ID)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/virtualnetworks_test.go
+++ b/virtualnetworks_test.go
@@ -4,7 +4,97 @@ import (
 	"testing"
 )
 
-func TestAccVirtualNetworks(t *testing.T) {
+func TestAccVirtualNetworksFacility(t *testing.T) {
+
+	skipUnlessAcceptanceTestsAllowed(t)
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+
+	l, _, err := c.ProjectVirtualNetworks.List(projectID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(l.VirtualNetworks) != 0 {
+		t.Fatal("Newly created project should not have any vlans")
+
+	}
+
+	testDesc := "test_desc_" + randString8()
+
+	cr := VirtualNetworkCreateRequest{
+		ProjectID:   projectID,
+		Description: testDesc,
+		Facility:    testFacility(),
+	}
+
+	vlan, _, err := c.ProjectVirtualNetworks.Create(&cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer c.ProjectVirtualNetworks.Delete(vlan.ID)
+
+	vlan, _, err = c.ProjectVirtualNetworks.Get(vlan.ID,
+		&GetOptions{Includes: []string{"assigned_to", "facility"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vlan.Metro != nil {
+		t.Fatalf("Metro should be null in facility-enabled VLAN")
+	}
+
+	if vlan.Facility.Code != testFacility() {
+		t.Fatalf("Wrong Facility in test VLAN, should be %s, was %s", testFacility(), vlan.Facility.Code)
+	}
+}
+
+func TestAccVirtualNetworksMetro(t *testing.T) {
+
+	skipUnlessAcceptanceTestsAllowed(t)
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+
+	l, _, err := c.ProjectVirtualNetworks.List(projectID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(l.VirtualNetworks) != 0 {
+		t.Fatal("Newly created project should not have any vlans")
+
+	}
+
+	testDesc := "test_desc_" + randString8()
+
+	cr := VirtualNetworkCreateRequest{
+		ProjectID:   projectID,
+		Description: testDesc,
+		Metro:       testMetro(),
+	}
+
+	vlan, _, err := c.ProjectVirtualNetworks.Create(&cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer c.ProjectVirtualNetworks.Delete(vlan.ID)
+
+	vlan, _, err = c.ProjectVirtualNetworks.Get(vlan.ID,
+		&GetOptions{Includes: []string{"assigned_to", "metro"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vlan.Facility != nil {
+		t.Fatalf("Facility should be null in metro-enabled VLAN")
+	}
+
+	if vlan.Metro.Code != testMetro() {
+		t.Fatalf("Wrong metro for testing VLAN, should be %s, was %s", testMetro(), vlan.Metro.Code)
+	}
+}
+
+func TestAccVirtualNetworksBasic(t *testing.T) {
 
 	skipUnlessAcceptanceTestsAllowed(t)
 	c, projectID, teardown := setupWithProject(t)


### PR DESCRIPTION
adds VLAN support for metros

(following this spotmarketrequests will still need metro support - the last create request field that is missing metros)