### PR TITLE
add missing metro country field

### DIFF
--- a/metros.go
+++ b/metros.go
@@ -13,9 +13,10 @@ type metroRoot struct {
 
 // Metro represents an Equinix Metal metro
 type Metro struct {
-	ID   string `json:"id"`
-	Name string `json:"name,omitempty"`
-	Code string `json:"code,omitempty"`
+	ID      string `json:"id"`
+	Name    string `json:"name,omitempty"`
+	Code    string `json:"code,omitempty"`
+	Country string `json:"country,omitempty"`
 }
 
 func (f Metro) String() string {


### PR DESCRIPTION
```
GET /metal/v1/locations/metros HTTP/1.1

{"metros": [
   ...
  {
   "id": "2991b022-b8c4-497e-8db7-5a407c3a209b",
   "name": "Silicon Valley",
   "code": "sv",
   "country": "US"
  }
  ...
], ...}
  ```