### PR TITLE
fix HardwareReservationServiceOp.List pagination

### DIFF
--- a/connections_test.go
+++ b/connections_test.go
@@ -51,7 +51,7 @@ func TestAccConnectionProject(t *testing.T) {
 	}
 
 	if port.ID != ports[0].ID {
-		t.Fatalf("Mismatch when getting Conenction Port, ID should be %s, was %s", ports[0].ID, port.ID)
+		t.Fatalf("Mismatch when getting Connection Port, ID should be %s, was %s", ports[0].ID, port.ID)
 	}
 
 	_, _, err = c.Connections.PortEvents(conn.ID, port.ID, nil)

--- a/hardware_reservations.go
+++ b/hardware_reservations.go
@@ -15,7 +15,7 @@ type HardwareReservationService interface {
 
 // HardwareReservationServiceOp implements HardwareReservationService
 type HardwareReservationServiceOp struct {
-	client *Client
+	client requestDoer
 }
 
 // HardwareReservation struct
@@ -42,20 +42,18 @@ type hardwareReservationRoot struct {
 
 // List returns all hardware reservations for a given project
 func (s *HardwareReservationServiceOp) List(projectID string, opts *ListOptions) (reservations []HardwareReservation, resp *Response, err error) {
-	root := new(hardwareReservationRoot)
-
 	endpointPath := path.Join(projectBasePath, projectID, hardwareReservationBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
 	for {
 		subset := new(hardwareReservationRoot)
 
-		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, root)
+		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, subset)
 		if err != nil {
 			return nil, resp, err
 		}
 
-		reservations = append(reservations, root.HardwareReservations...)
+		reservations = append(reservations, subset.HardwareReservations...)
 		if apiPathQuery = nextPage(subset.Meta, opts); apiPathQuery != "" {
 			continue
 		}

--- a/hardware_reservations_test.go
+++ b/hardware_reservations_test.go
@@ -71,6 +71,19 @@ func TestHardwareReservationServiceOp_List(t *testing.T) {
 		wantReservations: []HardwareReservation{{ID: "1"}, {ID: "2"}, {ID: "3"}},
 		wantResp:         &Response{},
 		wantErr:          false,
+	}, {
+		name: "Error",
+		fields: fields{
+			client: &MockClient{
+				fnDoRequest: func(method, path string, body, v interface{}) (*Response, error) {
+					return nil, errBoom
+				},
+			},
+		},
+		args:             args{},
+		wantReservations: nil,
+		wantResp:         nil,
+		wantErr:          true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hardware_reservations_test.go
+++ b/hardware_reservations_test.go
@@ -1,6 +1,11 @@
 package packngo
 
 import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -15,5 +20,74 @@ func TestAccListHardwareReservations(t *testing.T) {
 	}
 	if len(hardwareReservations) != 0 {
 		t.Fatal("There should not be any hardware reservations.")
+	}
+}
+
+func TestHardwareReservationServiceOp_List(t *testing.T) {
+	type fields struct {
+		client requestDoer
+	}
+	type args struct {
+		projectID string
+		opts      *ListOptions
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		wantReservations []HardwareReservation
+		wantResp         *Response
+		wantErr          bool
+	}{{
+		name: "Pagination",
+		fields: fields{
+			client: &MockClient{
+				fnDoRequest: func(method, path string, body, v interface{}) (*Response, error) {
+					// Return one reservation per page, tests pagination
+					data := []HardwareReservation{{ID: "1"}, {ID: "2"}, {ID: "3"}}
+
+					if v, ok := v.(*hardwareReservationRoot); ok && method == http.MethodGet {
+						u, _ := url.Parse(path)
+						q, _ := url.ParseQuery(u.RawQuery)
+						page, _ := strconv.Atoi(q.Get("page"))
+						if page == 0 {
+							page = 1
+						}
+						v.HardwareReservations = []HardwareReservation{data[page-1]}
+						v.Meta.Total = len(data)
+						v.Meta.CurrentPageNum = page
+						if page < v.Meta.Total {
+							nextPage := page + 1
+							v.Meta.Next = &Href{Href: fmt.Sprintf("%s?page=%d", u.Path, nextPage)}
+						}
+						return &Response{}, nil
+					}
+
+					return nil, errBoom
+				},
+			},
+		},
+		args:             args{},
+		wantReservations: []HardwareReservation{{ID: "1"}, {ID: "2"}, {ID: "3"}},
+		wantResp:         &Response{},
+		wantErr:          false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &HardwareReservationServiceOp{
+				client: tt.fields.client,
+			}
+			gotReservations, gotResp, err := s.List(tt.args.projectID, tt.args.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HardwareReservationServiceOp.List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotReservations, tt.wantReservations) {
+				t.Errorf("HardwareReservationServiceOp.List() gotReservations = %v, want %v", gotReservations, tt.wantReservations)
+			}
+			if !reflect.DeepEqual(gotResp, tt.wantResp) {
+				t.Errorf("HardwareReservationServiceOp.List() gotResp = %v, want %v", gotResp, tt.wantResp)
+			}
+		})
 	}
 }


### PR DESCRIPTION
A problem was identified in hardware reservation listing via https://github.com/packethost/packet-cli/issues/116.

This is due to not using the pagination loop scoped variable in HardwareReservationServiceOp.List.

Tests added emulate an API response with a single result per page. In the future we may wish to make this test structure generic for better reuse.

The test fails with the previous logic.