### PR TITLE
Publish state constants for Virtual Circuit 

### DIFF
--- a/virtualcircuits.go
+++ b/virtualcircuits.go
@@ -4,12 +4,25 @@ import "path"
 
 const (
 	virtualCircuitBasePath = "/virtual-circuits"
-	vcStatusActive         = "active"
-	vcStatusWaiting        = "waiting_on_customer_vlan"
-	//vcStatusActivating         = "activating"
-	//vcStatusDeactivating       = "deactivating"
-	vcStatusActivationFailed   = "activation_failed"
-	vcStatusDeactivationFailed = "dactivation_failed"
+
+	// VC is being create but not ready yet
+	VCStatusPending = "pending"
+
+	// VC is ready with a VLAN
+	VCStatusActive = "active"
+
+	// VC is ready without a VLAN
+	VCStatusWaiting = "waiting_on_customer_vlan"
+
+	// VC is being deleted
+	VCStatusDeleting = "deleting"
+
+	// not sure what the following states mean, or whether they exist
+	// someone from the API side could check
+	VCStatusActivating         = "activating"
+	VCStatusDeactivating       = "deactivating"
+	VCStatusActivationFailed   = "activation_failed"
+	VCStatusDeactivationFailed = "dactivation_failed"
 )
 
 type VirtualCircuitService interface {

--- a/virtualcircuits_test.go
+++ b/virtualcircuits_test.go
@@ -96,8 +96,8 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 	}
 	defer removeVirtualCircuit(t, c, vc.ID)
 
-	_, err = waitVirtualCircuitStatus(t, c, vc.ID, vcStatusActive,
-		[]string{vcStatusActivationFailed})
+	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusActive,
+		[]string{VCStatusActivationFailed})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,8 +115,8 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 
 	defer removeVirtualCircuit(t, c, vc2.ID)
 
-	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, vcStatusActive,
-		[]string{vcStatusActivationFailed})
+	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, VCStatusActive,
+		[]string{VCStatusActivationFailed})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,14 +130,14 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = waitVirtualCircuitStatus(t, c, vc.ID, vcStatusWaiting,
-		[]string{vcStatusDeactivationFailed})
+	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusWaiting,
+		[]string{VCStatusDeactivationFailed})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, vcStatusWaiting,
-		[]string{vcStatusDeactivationFailed})
+	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, VCStatusWaiting,
+		[]string{VCStatusDeactivationFailed})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if vc.Status == vcStatusActive {
+	if vc.Status == VCStatusActive {
 		vc, _, err = c.VirtualCircuits.Update(
 			vc.ID,
 			&VCUpdateRequest{VirtualNetworkID: nil},
@@ -175,8 +175,8 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = waitVirtualCircuitStatus(t, c, vc.ID, vcStatusWaiting,
-			[]string{vcStatusDeactivationFailed})
+		_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusWaiting,
+			[]string{VCStatusDeactivationFailed})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -205,8 +205,8 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = waitVirtualCircuitStatus(t, c, vc.ID, vcStatusActive,
-		[]string{vcStatusActivationFailed})
+	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusActive,
+		[]string{VCStatusActivationFailed})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,8 +231,8 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = waitVirtualCircuitStatus(t, c, vc.ID, vcStatusWaiting,
-		[]string{vcStatusDeactivationFailed})
+	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusWaiting,
+		[]string{VCStatusDeactivationFailed})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Virtual Circuits are sensitive to states, and we will need to wait for the states in the TF provider. This PR makes packngo export the relevant VC state consts.

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>