### PR TITLE
add device bandwidth support

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -93,7 +93,7 @@ func (b *BandwidthIO) UnmarshalJSON(buf []byte) error {
 	tmp := []interface{}{&b.Inbound, &b.Outbound}
 	wantLen := len(tmp)
 	if err := json.Unmarshal(buf, &tmp); err != nil {
-		return fmt.Errorf("foo %s", err)
+		return err
 	}
 	if g, e := len(tmp), wantLen; g != e {
 		return fmt.Errorf("wrong number of fields in BandwidthIO: %d != %d", g, e)
@@ -105,7 +105,7 @@ func (b *BandwidthIO) UnmarshalJSON(buf []byte) error {
 }
 
 type bandwidthRoot struct {
-	Components BandwidthIO `json:"bandwidth"`
+	Bandwidth BandwidthIO `json:"bandwidth"`
 }
 
 type BandwidthTarget string
@@ -148,7 +148,7 @@ func (d *Datapoint) UnmarshalJSON(buf []byte) error {
 	tmp := []interface{}{&d.Rate, &d.When}
 	wantLen := len(tmp)
 	if err := json.Unmarshal(buf, &tmp); err != nil {
-		return fmt.Errorf("bar %s", err)
+		return err
 	}
 	if g, e := len(tmp), wantLen; g != e {
 		return fmt.Errorf("wrong number of fields in BandwidthComponent: %d != %d", g, e)
@@ -167,10 +167,10 @@ func (b *BandwidthOpts) Encode() string {
 	}
 	v := url.Values{}
 	if b.From != nil {
-		v.Add("from", strconv.FormatInt(b.From.Unix(), 10))
+		v.Add("from", strconv.FormatInt(b.From.UTC().Unix(), 10))
 	}
 	if b.Until != nil {
-		v.Add("until", strconv.FormatInt(b.Until.Unix(), 10))
+		v.Add("until", strconv.FormatInt(b.Until.UTC().Unix(), 10))
 	}
 	return v.Encode()
 }
@@ -185,14 +185,14 @@ func (b *BandwidthOpts) WithQuery(apiPath string) string {
 }
 
 func (d *DeviceServiceOp) GetBandwidth(deviceID string, opts *BandwidthOpts) (*BandwidthIO, *Response, error) {
-	endpointPath := path.Join(deviceBasePath, deviceID, "/bandwidth")
+	endpointPath := path.Join(deviceBasePath, deviceID, "bandwidth")
 	apiPathQuery := opts.WithQuery(endpointPath)
 	bw := new(bandwidthRoot)
 	resp, err := d.client.DoRequest("GET", apiPathQuery, nil, bw)
 	if err != nil {
 		return nil, resp, err
 	}
-	return &bw.Components, resp, nil
+	return &bw.Bandwidth, resp, nil
 }
 
 func (d *Device) GetNetworkInfo() NetworkInfo {

--- a/devices_test.go
+++ b/devices_test.go
@@ -1655,3 +1655,39 @@ func TestAccDeviceMetroBasic(t *testing.T) {
 	}
 
 }
+
+func TestDatapoint_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		buf []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Datapoint
+		wantErr bool
+	}{{
+		name: "RateAndWhen",
+		args: args{buf: []byte(`[1,1609459200]`)},
+		want: Datapoint{
+			Rate: func(f float64) *float64 {
+				return &f
+			}(1),
+			When: Timestamp{Time: time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)}},
+		wantErr: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := &Datapoint{}
+			if err := got.UnmarshalJSON(tt.args.buf); (err != nil) != tt.wantErr {
+				t.Errorf("Datapoint.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got.When != tt.want.When {
+				t.Errorf("want Datapoint.When %v, got %v", tt.want.When, got.When)
+			}
+			if *got.Rate != *tt.want.Rate {
+				t.Errorf("want Datapoint.Rate %v, got %v", *tt.want.Rate, *got.Rate)
+			}
+		})
+	}
+}

--- a/timestamp.go
+++ b/timestamp.go
@@ -24,7 +24,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	if err == nil {
 		t.Time = time.Unix(i, 0)
 	} else {
-		t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str)
+		if t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str); err != nil {
+			return err
+		}
 	}
 	return
 }

--- a/timestamp.go
+++ b/timestamp.go
@@ -2,6 +2,7 @@ package packngo
 
 import (
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -22,9 +23,9 @@ func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	str := string(data)
 	i, err := strconv.ParseInt(str, 10, 64)
 	if err == nil {
-		t.Time = time.Unix(i, 0)
+		t.Time = time.Unix(i, 0).UTC()
 	} else {
-		if t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str); err != nil {
+		if t.Time, err = time.ParseInLocation(time.RFC3339, strings.Trim(str, `"`), time.UTC); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Adds support for fetching Device Bandwidth. This endpoint is not well documented in the API spec so I used the Portal as a reference.

```
GET https://api.packet.net/devices/{id}/bandwidth?from=1620340085&until=1620426485
```

The timestamps here are UNIX timestamps. I am making the assumption that these are both optional and that defaults will be provided if omitted.

The response has hundreds of datapoints, I've cut the majority out for this example snippet:
```json
{"bandwidth":[
  {
    "target":"inbound",
    "tags":{"aggregatedBy":"sum","name":"inbound"},
    "datapoints":[[291.2194575,1620340560],[288.3348246666667,1620340920],[293.0455313333334,1620341280]]
  },{
    "target":"outbound",
    "tags":{"aggregatedBy":"sum","name":"outbound"},
    "datapoints":[[27.53298983333333,1620340560],[25.11672366666667,1620340920],[32.03483233333333,1620341280]]
}
]}
```

In this PR, I've transformed the returned `bandwidth` array of `inbound` and `output` objects into a structure.  I would like to confirm that this is a reasonable deviation from the API spec and that in/out are the only two array members ever returned before proceeding with this PR.

I've also transformed the tuple of bandwidth used at a timestamp into a structure of `rate` and `when`.