### PR TITLE
replace Version const with a var determined at runtime

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,15 +20,6 @@ they can be run in the absence of that automation.
   git branch --points-at=master -r  | grep origin/master >/dev/null || echo "master differs from origin/master"
   ```
 
-* Update the `Version` variable. This is a library, so we can not assure
-  that a build flag will be used in every client that provides a compile time
-  value, let alone the correct one.
-
-  ```sh
-  vim version.go # change Version, "0.8.0" (no v)
-  git commit --signoff -m 'v0.8.0 version bump' version.go
-  ```
-
 * Tag `master` with a semver tag that suits the level of changes
   introduced:
 

--- a/packngo.go
+++ b/packngo.go
@@ -28,9 +28,6 @@ const (
 	headerRateRemaining          = "X-RateLimit-Remaining"
 	headerRateReset              = "X-RateLimit-Reset"
 	expectedAPIContentTypePrefix = "application/json"
-
-	// UserAgent is the default HTTP User-Agent Header value that will be used by NewClient
-	UserAgent = "packngo/" + Version
 )
 
 // meta contains pagination information

--- a/version.go
+++ b/version.go
@@ -2,8 +2,14 @@ package packngo
 
 import "runtime/debug"
 
-// Version of the packngo package
-var Version = "(devel)"
+var (
+	// Version of the packngo package. Version will be updated at runtime.
+	Version = "(devel)"
+
+	// UserAgent is the default HTTP User-Agent Header value that will be used by NewClient.
+	// init() will update the version to match the built version of packngo.
+	UserAgent = "packngo/(devel)"
+)
 
 const packagePath = "github.com/packethost/packngo"
 
@@ -20,6 +26,7 @@ func init() {
 			if d.Replace != nil {
 				Version = d.Replace.Version
 			}
+			UserAgent = "packngo/" + Version
 			break
 		}
 	}

--- a/version.go
+++ b/version.go
@@ -24,7 +24,10 @@ func init() {
 		if d.Path == packagePath {
 			Version = d.Version
 			if d.Replace != nil {
-				Version = d.Replace.Version
+				v := d.Replace.Version
+				if v != "" {
+					Version = v
+				}
 			}
 			UserAgent = "packngo/" + Version
 			break

--- a/version.go
+++ b/version.go
@@ -1,4 +1,26 @@
 package packngo
 
+import "runtime/debug"
+
 // Version of the packngo package
-const Version = "0.14.1"
+var Version = "(devel)"
+
+const packagePath = "github.com/packethost/packngo"
+
+// init finds packngo in the dependency so the package Version can be properly
+// reflected in API UserAgent headers and client introspection
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, d := range bi.Deps {
+		if d.Path == packagePath {
+			Version = d.Version
+			if d.Replace != nil {
+				Version = d.Replace.Version
+			}
+			break
+		}
+	}
+}


### PR DESCRIPTION
debug.BuildInfo is a way that we can get the packngo version dynamically at runtime.
This change will allow us to make automated releases without intervening in the process to update the Version variable contained in version.go

https://golang.org/pkg/runtime/debug/#BuildInfo

https://www.reddit.com/r/golang/comments/lqkkiz/creating_dynamic_version_numbers_in_go_116/
* https://github.com/golang/go/issues/29228
