### PR TITLE
Format and indent json from HTTP response body in debug mode

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -267,9 +267,22 @@ func dumpDeprecation(resp *http.Response) {
 	}
 }
 
+// from terraform-plugin-sdk/v2/helper/logging/transport.go
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 func dumpResponse(resp *http.Response) {
 	o, _ := httputil.DumpResponse(resp, true)
-	strResp := string(o)
+	strResp := prettyPrintJsonLines(o)
 	reg, _ := regexp.Compile(`"token":(.+?),`)
 	reMatches := reg.FindStringSubmatch(strResp)
 	if len(reMatches) == 2 {

--- a/packngo.go
+++ b/packngo.go
@@ -302,9 +302,9 @@ func dumpRequest(req *http.Request) {
 
 	o, _ := httputil.DumpRequestOut(r, false)
 	bbs, _ := ioutil.ReadAll(r.Body)
-
-	strReq := string(o)
-	log.Printf("\n=======[REQUEST]=============\n%s%s\n", string(strReq), string(bbs))
+	reqBodyStr := prettyPrintJsonLines(bbs)
+	strReq := prettyPrintJsonLines(o)
+	log.Printf("\n=======[REQUEST]=============\n%s%s\n", string(strReq), reqBodyStr)
 }
 
 // DoRequest is a convenience method, it calls NewRequest followed by Do

--- a/packngo.go
+++ b/packngo.go
@@ -273,7 +273,7 @@ func prettyPrintJsonLines(b []byte) string {
 	for i, p := range parts {
 		if b := []byte(p); json.Valid(b) {
 			var out bytes.Buffer
-			json.Indent(&out, b, "", " ")
+			_ = json.Indent(&out, b, "", " ")
 			parts[i] = out.String()
 		}
 	}


### PR DESCRIPTION
This PR adds formatting and indentation to debug prints of JSON from HTTP responses. It makes the HTTP traffic more readable and greppable. It will make the debug look like this, project creation:

```
2021/07/09 14:59:52 
=======[REQUEST]=============
PATCH /metal/v1/projects/2c389b61-fd14-46ef-abb6-4fb4d3445634 HTTP/1.1
Host: api.equinix.com
User-Agent: packngo/(devel)
Connection: close
Content-Length: 48
Accept: application/json
Content-Type: application/json
X-Auth-Token: **REDACTED**
X-Consumer-Token: packngo test
Accept-Encoding: gzip

{"name":"PACKNGO_TEST_DELME_2d768716_QZEYplKy"}

2021/07/09 14:59:53 
=======[RESPONSE]============
HTTP/1.1 200 OK
Connection: close
Content-Length: 653
Cache-Control: max-age=0, private, must-revalidate
Content-Type: application/json; charset=utf-8
Date: Fri, 09 Jul 2021 11:59:53 GMT
Etag: W/"1847c2a67e6b038631c92b473a76e8c7"
Set-Cookie: ak_bmsc=69B990B79F2D362D0C906931B82EC308~000000000000000000000000000000~YAAQJKwXAnLUq4N6AQAAn28jiwx1TKSDzsJl2q30aHhYRtfVCxzCNr/QrztxUC2fB6MRMlC8rO9qBV9JLZue908z8S3qbCxufM7GWfmSBbBkBOj1Q1/znN1kqaGc5e7fwUsmMu8PSzfdEJSXNiIhHaRcWGxujK7gwZXvCKgwXIwyRkUngPQkbYC3NcivdRL5M5jnoj5q5ZBbrjcLoHjCrgRb99NtEYWH1R7ZSgypecsfTK9o2CB1mLSAV9MJRtgffdaIQksI/EhDqka4SDGdy+aKWat+6tQZPFIeWb9hAQKUqE0/brHZ5u8AHEi0sXoI8P0ttvnG0kXhZE0GmxZFBCi6Tq3QMRjr5nrlKGUj+MxHaEmKSMeAYt/EOoSFFscuXA==; Domain=.equinix.com; Path=/; Expires=Fri, 09 Jul 2021 13:59:53 GMT; Max-Age=7200; HttpOnly
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-Request-Id: f5a1f4dbc025ec10cf090db1420eb63c

{
 "id": "2c389b61-fd14-46ef-abb6-4fb4d3445634",
 "name": "PACKNGO_TEST_DELME_2d768716_QZEYplKy",
 "created_at": "2021-07-09T11:59:52Z",
 "updated_at": "2021-07-09T11:59:53Z",
 "backend_transfer_enabled": false,
 "customdata": {},
 "event_alert_configuration": null,
 "memberships": [],
 "invitations": [],
 "devices": [],
 "ssh_keys": [],
 "volumes": [],
 "members": [
  {
   "href": "/metal/v1/users/ae8b343c-8800-44ff-a31f-edd1a2cbf86d"
  }
 ],
 "payment_method": {
  "href": "/metal/v1/payment-methods/845b45a3-c565-47e5-b9b6-a86204a73d29"
 },
 "transfers": [],
 "organization": {
  "href": "/metal/v1/organizations/70c2f878-9f32-452e-8c69-ab15480e1d99"
 },
 "href": "/metal/v1/projects/2c389b61-fd14-46ef-abb6-4fb4d3445634"
}

```


Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>

