### PR TITLE
Add NoSSHKeys to DeviceCreateRequest

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -411,6 +411,7 @@ type DeviceCreateRequest struct {
 	ProjectSSHKeys []string                 `json:"project_ssh_keys,omitempty"`
 	Features       map[string]string        `json:"features,omitempty"`
 	IPAddresses    []IPAddressCreateRequest `json:"ip_addresses,omitempty"`
+	NoSSHKeys      bool                     `json:"no_ssh_keys,omitempty"`
 }
 
 // DeviceUpdateRequest type used to update an Equinix Metal device


### PR DESCRIPTION
This PR adds NoSSHKeys/`no_ssh_keys` to the device create request

towards https://github.com/equinix/terraform-provider-metal/issues/148

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>