### PR TITLE
Bulk VLAN Assignments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.16.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMG ?= golang:1.15
+IMG ?= golang:1.16
 
 # enable go modules, disabled CGO
 

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a
 )
 
-go 1.15
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/packethost/packngo
 
 require (
 	github.com/dnaeon/go-vcr v1.0.1
-	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-cmp v0.5.6
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a
 )

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/packethost/packngo
 
 require (
 	github.com/dnaeon/go-vcr v1.0.1
+	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -15,6 +17,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1,0 +1,114 @@
+package packngo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// MockClient makes it simpler to test the Client
+type MockClient struct {
+	fnNewRequest          func(method, path string, body interface{}) (*http.Request, error)
+	fnDo                  func(req *http.Request, v interface{}) (*Response, error)
+	fnDoRequest           func(method, path string, body, v interface{}) (*Response, error)
+	fnDoRequestWithHeader func(method string, headers map[string]string, path string, body, v interface{}) (*Response, error)
+}
+
+var _ requestDoer = &MockClient{}
+
+// NewRequest uses the mock NewRequest function
+func (mc *MockClient) NewRequest(method, path string, body interface{}) (*http.Request, error) {
+	return mc.fnNewRequest(method, path, body)
+}
+
+// Do uses the mock Do function
+func (mc *MockClient) Do(req *http.Request, v interface{}) (*Response, error) {
+	return mc.fnDo(req, v)
+}
+
+// DoRequest uses the mock DoRequest function
+func (mc *MockClient) DoRequest(method, path string, body, v interface{}) (*Response, error) {
+	return mc.fnDoRequest(method, path, body, v)
+}
+
+func mockDoRequestWithHeader(doFn func(req *http.Request, v interface{}) (*Response, error), newRequestFn func(method, path string, body interface{}) (*http.Request, error)) func(string, map[string]string, string, interface{}, interface{}) (*Response, error) {
+	return func(method string, headers map[string]string, path string, body, v interface{}) (*Response, error) {
+		req, err := newRequestFn(method, path, body)
+		for k, v := range headers {
+			req.Header.Add(k, v)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+		return doFn(req, v)
+	}
+}
+func mockNewRequest() func(string, string, interface{}) (*http.Request, error) {
+	baseURL := &url.URL{}
+	apiKey, consumerToken, userAgent := "", "", ""
+	return func(method, path string, body interface{}) (*http.Request, error) {
+		// relative path to append to the endpoint url, no leading slash please
+		if path[0] == '/' {
+			path = path[1:]
+		}
+		rel, err := url.Parse(path)
+		if err != nil {
+			return nil, err
+		}
+
+		u := baseURL.ResolveReference(rel)
+
+		// json encode the request body, if any
+		buf := new(bytes.Buffer)
+		if body != nil {
+			err := json.NewEncoder(buf).Encode(body)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		req, err := http.NewRequest(method, u.String(), buf)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Close = true
+
+		req.Header.Add("X-Auth-Token", apiKey)
+		req.Header.Add("X-Consumer-Token", consumerToken)
+
+		req.Header.Add("Content-Type", mediaType)
+		req.Header.Add("Accept", mediaType)
+		req.Header.Add("User-Agent", userAgent)
+		return req, nil
+	}
+}
+
+func mockDoRequest(newRequestFn func(string, string, interface{}) (*http.Request, error), doFn func(*http.Request, interface{}) (*Response, error)) func(method, path string, body, v interface{}) (*Response, error) {
+	return func(method, path string, body, v interface{}) (*Response, error) {
+		req, err := newRequestFn(method, path, body)
+		if err != nil {
+			return nil, err
+		}
+		return doFn(req, v)
+	}
+}
+
+// DoRequestWithHeader uses the mock DoRequestWithHeader function
+func (mc *MockClient) DoRequestWithHeader(method string, headers map[string]string, path string, body, v interface{}) (*Response, error) {
+	return mc.fnDoRequestWithHeader(method, headers, path, body, v)
+}
+
+func mockResponse(code int, body string, req *http.Request) *Response {
+	return &Response{Response: &http.Response{
+		Status:        fmt.Sprintf("%d Ignored", code),
+		StatusCode:    code,
+		Body:          io.NopCloser(bytes.NewReader([]byte(body))),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}}
+}

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -34,6 +34,7 @@ func (mc *MockClient) DoRequest(method, path string, body, v interface{}) (*Resp
 	return mc.fnDoRequest(method, path, body, v)
 }
 
+/* deadcode, for now
 func mockDoRequestWithHeader(doFn func(req *http.Request, v interface{}) (*Response, error), newRequestFn func(method, path string, body interface{}) (*http.Request, error)) func(string, map[string]string, string, interface{}, interface{}) (*Response, error) {
 	return func(method string, headers map[string]string, path string, body, v interface{}) (*Response, error) {
 		req, err := newRequestFn(method, path, body)
@@ -47,6 +48,8 @@ func mockDoRequestWithHeader(doFn func(req *http.Request, v interface{}) (*Respo
 		return doFn(req, v)
 	}
 }
+*/
+
 func mockNewRequest() func(string, string, interface{}) (*http.Request, error) {
 	baseURL := &url.URL{}
 	apiKey, consumerToken, userAgent := "", "", ""

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -107,7 +107,7 @@ func mockResponse(code int, body string, req *http.Request) *Response {
 	return &Response{Response: &http.Response{
 		Status:        fmt.Sprintf("%d Ignored", code),
 		StatusCode:    code,
-		Body:          io.NopCloser(bytes.NewReader([]byte(body))),
+		Body:          ioutil.NopCloser(bytes.NewReader([]byte(body))), // TODO: io.NopCloser requires go 1.16+
 		ContentLength: int64(len(body)),
 		Request:       req,
 	}}

--- a/packngo.go
+++ b/packngo.go
@@ -122,6 +122,8 @@ type Client struct {
 	TwoFactorAuth          TwoFactorAuthService
 	Users                  UserService
 	VirtualCircuits        VirtualCircuitService
+	VLANAssignments        VLANAssignmentService
+	VLANAssignmentBatches  VLANAssignmentBatchService
 	VolumeAttachments      VolumeAttachmentService
 	Volumes                VolumeService
 
@@ -393,6 +395,8 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.VirtualCircuits = &VirtualCircuitServiceOp{client: c}
 	c.VolumeAttachments = &VolumeAttachmentServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}
+	c.VLANAssignments = &VLANAssignmentServiceOp{client: c}
+	c.VLANAssignmentBatches = &VLANAssignmentBatchServiceOp{client: c}
 	c.debug = os.Getenv(debugEnvVar) != ""
 
 	return c, nil

--- a/packngo.go
+++ b/packngo.go
@@ -123,7 +123,6 @@ type Client struct {
 	Users                  UserService
 	VirtualCircuits        VirtualCircuitService
 	VLANAssignments        VLANAssignmentService
-	VLANAssignmentBatches  VLANAssignmentBatchService
 	VolumeAttachments      VolumeAttachmentService
 	Volumes                VolumeService
 
@@ -396,7 +395,6 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.VolumeAttachments = &VolumeAttachmentServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}
 	c.VLANAssignments = &VLANAssignmentServiceOp{client: c}
-	c.VLANAssignmentBatches = &VLANAssignmentBatchServiceOp{client: c}
 	c.debug = os.Getenv(debugEnvVar) != ""
 
 	return c, nil

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -82,36 +82,6 @@ func randString8() string {
 	return string(b)
 }
 
-// MockClient makes it simpler to test the Client
-type MockClient struct {
-	fnNewRequest          func(method, path string, body interface{}) (*http.Request, error)
-	fnDo                  func(req *http.Request, v interface{}) (*Response, error)
-	fnDoRequest           func(method, path string, body, v interface{}) (*Response, error)
-	fnDoRequestWithHeader func(method string, headers map[string]string, path string, body, v interface{}) (*Response, error)
-}
-
-var _ requestDoer = &MockClient{}
-
-// NewRequest uses the mock NewRequest function
-func (mc *MockClient) NewRequest(method, path string, body interface{}) (*http.Request, error) {
-	return mc.fnNewRequest(method, path, body)
-}
-
-// Do uses the mock Do function
-func (mc *MockClient) Do(req *http.Request, v interface{}) (*Response, error) {
-	return mc.fnDo(req, v)
-}
-
-// DoRequest uses the mock DoRequest function
-func (mc *MockClient) DoRequest(method, path string, body, v interface{}) (*Response, error) {
-	return mc.fnDoRequest(method, path, body, v)
-}
-
-// DoRequestWithHeader uses the mock DoRequestWithHeader function
-func (mc *MockClient) DoRequestWithHeader(method string, headers map[string]string, path string, body, v interface{}) (*Response, error) {
-	return mc.fnDoRequestWithHeader(method, headers, path, body, v)
-}
-
 // setupWithProject returns a client, project id, and teardown function
 // configured for a new project with a test recorder for the named test
 func setupWithProject(t *testing.T) (*Client, string, func()) {

--- a/ports.go
+++ b/ports.go
@@ -43,6 +43,8 @@ type BondData struct {
 // Port is a hardware port associated with a reserved or instantiated hardware
 // device.
 type Port struct {
+	*Href `json:",inline"`
+
 	// ID of the Port
 	ID string `json:"id"`
 

--- a/vlan_assignments.go
+++ b/vlan_assignments.go
@@ -23,24 +23,17 @@ type vlanAssignmentBatchesRoot struct {
 type VLANAssignmentService interface {
 	Get(string, string, *GetOptions) (*VLANAssignment, *Response, error)
 	List(string, *ListOptions) ([]VLANAssignment, *Response, error)
-}
 
-type VLANAssignmentBatchService interface {
-	Get(string, string, *GetOptions) (*VLANAssignmentBatch, *Response, error)
-	List(string, *ListOptions) ([]VLANAssignmentBatch, *Response, error)
-	Create(string, *VLANAssignmentBatchCreateRequest, *GetOptions) (*VLANAssignmentBatch, *Response, error)
+	GetBatch(string, string, *GetOptions) (*VLANAssignmentBatch, *Response, error)
+	ListBatch(string, *ListOptions) ([]VLANAssignmentBatch, *Response, error)
+	CreateBatch(string, *VLANAssignmentBatchCreateRequest, *GetOptions) (*VLANAssignmentBatch, *Response, error)
 }
 
 type VLANAssignmentServiceOp struct {
 	client requestDoer
 }
 
-type VLANAssignmentBatchServiceOp struct {
-	client requestDoer
-}
-
 var _ VLANAssignmentService = (*VLANAssignmentServiceOp)(nil)
-var _ VLANAssignmentBatchService = (*VLANAssignmentBatchServiceOp)(nil)
 
 type VLANAssignmentBatchState string
 
@@ -96,7 +89,7 @@ type VLANAssignmentCreateRequest struct {
 }
 
 // List returns VLANAssignmentBatches
-func (s *VLANAssignmentBatchServiceOp) List(portID string, opts *ListOptions) (results []VLANAssignmentBatch, resp *Response, err error) {
+func (s *VLANAssignmentServiceOp) ListBatch(portID string, opts *ListOptions) (results []VLANAssignmentBatch, resp *Response, err error) {
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, portVLANAssignmentsBatchPath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -117,7 +110,7 @@ func (s *VLANAssignmentBatchServiceOp) List(portID string, opts *ListOptions) (r
 }
 
 // Get returns a VLANAssignmentBatch by id
-func (s *VLANAssignmentBatchServiceOp) Get(portID, batchID string, opts *GetOptions) (*VLANAssignmentBatch, *Response, error) {
+func (s *VLANAssignmentServiceOp) GetBatch(portID, batchID string, opts *GetOptions) (*VLANAssignmentBatch, *Response, error) {
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, portVLANAssignmentsBatchPath, batchID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	batch := new(VLANAssignmentBatch)
@@ -129,7 +122,7 @@ func (s *VLANAssignmentBatchServiceOp) Get(portID, batchID string, opts *GetOpti
 }
 
 // Create creates VLANAssignmentBatch objects
-func (s *VLANAssignmentBatchServiceOp) Create(portID string, request *VLANAssignmentBatchCreateRequest, opts *GetOptions) (*VLANAssignmentBatch, *Response, error) {
+func (s *VLANAssignmentServiceOp) CreateBatch(portID string, request *VLANAssignmentBatchCreateRequest, opts *GetOptions) (*VLANAssignmentBatch, *Response, error) {
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, portVLANAssignmentsBatchPath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	batch := new(VLANAssignmentBatch)

--- a/vlan_assignments.go
+++ b/vlan_assignments.go
@@ -53,14 +53,26 @@ const (
 
 // VLANAssignment struct for VLANAssignment
 type VLANAssignment struct {
-	ID             string              `json:"id,omitempty"`
-	CreatedAt      Timestamp           `json:"created_at,omitempty"`
-	UpdatedAt      Timestamp           `json:"updated_at,omitempty"`
-	Native         bool                `json:"native,omitempty"`
-	State          VLANAssignmentState `json:"state,omitempty"`
-	VLAN           int                 `json:"vlan,omitempty"`
-	Port           *Port               `json:"port,omitempty"`
-	VirtualNetwork *VirtualNetwork     `json:"virtual_network,omitempty"`
+	// ID is the VirtualNetwork.ID of the VLAN the assignment was made to
+	ID string `json:"id,omitempty"`
+
+	CreatedAt Timestamp `json:"created_at,omitempty"`
+	UpdatedAt Timestamp `json:"updated_at,omitempty"`
+
+	// Native indicates the VLAN is the native VLAN on the port and packets for this vlan will be untagged
+	Native bool `json:"native,omitempty"`
+
+	// State of the assignment
+	State VLANAssignmentState `json:"state,omitempty"`
+
+	// VLAN is the VirtualNetwork.VXLAN of the VLAN the assignment was made to
+	VLAN int `json:"vlan,omitempty"`
+
+	// Port is a reference to the Port the assignment was made on
+	Port *Port `json:"port,omitempty"`
+
+	// VirtualNetwork is a reference to the VLAN the assignment was made to
+	VirtualNetwork *VirtualNetwork `json:"virtual_network,omitempty"`
 }
 
 // VLANAssignmentBatch struct for VLANAssignmentBatch
@@ -83,9 +95,9 @@ type VLANAssignmentBatchCreateRequest struct {
 
 // VLANAssignmentCreateRequest struct for VLANAssignmentBatchCreateRequest
 type VLANAssignmentCreateRequest struct {
-	VLAN   string `json:"vlan,omitempty"`
-	State  string `json:"state,omitempty"`
-	Native *bool  `json:"native,omitempty"`
+	VLAN   string              `json:"vlan,omitempty"`
+	State  VLANAssignmentState `json:"state,omitempty"`
+	Native *bool               `json:"native,omitempty"`
 }
 
 // List returns VLANAssignmentBatches

--- a/vlan_assignments.go
+++ b/vlan_assignments.go
@@ -51,9 +51,9 @@ const (
 	VLANAssignmentUnassigned VLANAssignmentState = "unassigned"
 )
 
-// VLANAssignment struct for VLANAssignment
+// VLANAssignment struct for VLANAssignmentService.Get represents a port VLAN assignment that has been enacted
 type VLANAssignment struct {
-	// ID is the VirtualNetwork.ID of the VLAN the assignment was made to
+	// ID of the assignment
 	ID string `json:"id,omitempty"`
 
 	CreatedAt Timestamp `json:"created_at,omitempty"`
@@ -75,6 +75,21 @@ type VLANAssignment struct {
 	VirtualNetwork *VirtualNetwork `json:"virtual_network,omitempty"`
 }
 
+// BatchedVLANAssignment represents the data requested in the batch before being processed. ID represents the VLAN ID, not the VLAN Assignment ID.
+type BatchedVLANAssignment struct {
+	// VirtualNetworkID is the VirtualNetwork.ID of the VLAN the assignment was made to
+	VirtualNetworkID string `json:"id,omitempty"`
+
+	// Native indicates the VLAN is the native VLAN on the port and packets for this vlan will be untagged
+	Native bool `json:"native,omitempty"`
+
+	// State of the assignment
+	State VLANAssignmentState `json:"state,omitempty"`
+
+	// VLAN is the VirtualNetwork.VXLAN of the VLAN the assignment was made to
+	VLAN int `json:"vlan,omitempty"`
+}
+
 // VLANAssignmentBatch struct for VLANAssignmentBatch
 type VLANAssignmentBatch struct {
 	ID              string                   `json:"id,omitempty"`
@@ -85,7 +100,7 @@ type VLANAssignmentBatch struct {
 	UpdatedAt       Timestamp                `json:"updated_at,omitempty"`
 	Port            *Port                    `json:"port,omitempty"`
 	Project         *Project                 `json:"project,omitempty"`
-	VLANAssignments []VLANAssignment         `json:"vlan_assignments,omitempty"`
+	VLANAssignments []BatchedVLANAssignment  `json:"vlan_assignments,omitempty"`
 }
 
 // VLANAssignmentBatchCreateRequest struct for VLANAssignmentBatch Create

--- a/vlan_assignments_test.go
+++ b/vlan_assignments_test.go
@@ -1,0 +1,111 @@
+package packngo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func mockAssignedPortBody(assignmentid, portid, vnid string) string {
+	return fmt.Sprintf(`{
+		"id":"%s",
+		"created_at":"2021-05-28T16:02:33Z",
+		"updated_at":"2021-05-28T16:02:33Z",
+		"native":false,
+		"virtual_network":
+		   {"href":"/virtual-networks/%s"},
+		"port":{"href":"/ports/%s"},
+		"vlan":1234,
+		"state":"assigned"
+	}`, assignmentid, vnid, portid)
+}
+
+func TestVLANAssignmentServiceOp_Get(t *testing.T) {
+	type fields struct {
+		client requestDoer
+	}
+	type args struct {
+		portID       string
+		assignmentID string
+		opts         *GetOptions
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *VLANAssignment
+		wantErr bool
+	}{
+		{
+			name: "Simple",
+			fields: fields{
+				client: (func() *MockClient {
+
+					raw := mockAssignedPortBody("bar", "foo", "vlan")
+					mockNR := mockNewRequest()
+					mockDo := func(req *http.Request, obj interface{}) (*Response, error) {
+						// baseURL is not needed here
+						expectedPath := path.Join(portBasePath, "foo", portVLANAssignmentsPath, "bar")
+						if expectedPath != req.URL.Path {
+							return nil, fmt.Errorf("wrong url")
+						}
+						if err := json.NewDecoder(strings.NewReader(raw)).Decode(obj); err != nil {
+							return nil, err
+						}
+
+						return mockResponse(200, raw, req), nil
+					}
+
+					return &MockClient{
+						fnDoRequest: mockDoRequest(mockNR, mockDo),
+					}
+				})(),
+			},
+			args: args{portID: "foo", assignmentID: "bar"},
+			want: &VLANAssignment{
+				ID:             "bar",
+				CreatedAt:      Timestamp{Time: func() time.Time { t, _ := time.Parse(time.RFC3339, "2021-05-28T16:02:33Z"); return t }()},
+				UpdatedAt:      Timestamp{Time: func() time.Time { t, _ := time.Parse(time.RFC3339, "2021-05-28T16:02:33Z"); return t }()},
+				VirtualNetwork: &VirtualNetwork{Href: "/virtual-networks/vlan"},
+				Port:           &Port{Href: &Href{Href: "/ports/foo"}},
+				VLAN:           1234,
+				State:          VLANAssignmentAssigned,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error",
+			fields: fields{
+				client: &MockClient{
+					fnDoRequest: func(method, path string, body, v interface{}) (*Response, error) {
+						return nil, errBoom
+					},
+				},
+			},
+			args:    args{},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &VLANAssignmentServiceOp{
+				client: tt.fields.client,
+			}
+			got, _, err := s.Get(tt.args.portID, tt.args.assignmentID, tt.args.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VLANAssignmentServiceOp.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("VLANAssignmentServiceOp.Get() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #291

**Warning: bumps go required version to 1.16 for io.NopCloser (https://pkg.go.dev/io/ioutil), this could be avoided if we use the deprecated ioutil function**

Implements the following new endpoints for batch assignment of stateful VLAN assignments:
```
POST /ports/{port uuid}/vlan-assignments/batches
GET /ports/{port uuid}/vlan-assignments/batches/{batch id}
GET /ports/{port uuid}/vlan-assignments/batches
GET /ports/{port uuid}/vlan-assignments/
GET /ports/{port uuid}/vlan-assignments/{id}
```

An advantage of these endpoints is that the port definition can be expressed statefully. This prevents errors like those seen in the existing RPC style endpoints:
* `Error: POST https://api.equinix.com/metal/v1/ports/45fde0ea-6052-4f25-b311-bb4f4c201277/disbond: 422 Bond operations on port eth1 are not supported while the Hybrid bonded mode is enabled`
* `Error: POST https://api.equinix.com/metal/v1/ports/21a5929e-7503-4ee9-bbab-5d689dd1c6e8/convert/layer-3: 422 The port already has a public IPv4 assignment, The port already has a private IPv4 assignment, The port already has a public IPv6 assignment`