### PR TITLE
Implement arbitrary options in ListOptions, enabling filtering

### DIFF
--- a/api_call_options.go
+++ b/api_call_options.go
@@ -37,6 +37,9 @@ type GetOptions struct {
 	// their `Href` field.
 	Excludes []string `url:"exclude,omitempty,comma"`
 
+	// Arbitrary params for API URL, used for arbitrary filters
+	ArbitraryOpts map[string]string `url:"-"`
+
 	// Page is the page of results to retrieve for paginated result sets
 	Page int `url:"page,omitempty"`
 
@@ -107,6 +110,20 @@ func (g *GetOptions) CopyOrNew() *GetOptions {
 	return &ret
 }
 
+func (g *GetOptions) Filter(key, value string) *GetOptions {
+	return g.AddOpt(key, value)
+}
+
+// AddOpt adds key=value to URL path
+func (g *GetOptions) AddOpt(key, value string) *GetOptions {
+	ret := g.CopyOrNew()
+	if ret.ArbitraryOpts == nil {
+		ret.ArbitraryOpts = map[string]string{}
+	}
+	ret.ArbitraryOpts[key] = value
+	return ret
+}
+
 // Including ensures that the variadic refs are included in a copy of the
 // options, resulting in expansion of the the referred sub-resources. Unknown
 // values within refs will be silently ignore by the API.
@@ -152,32 +169,46 @@ func nextPage(meta meta, opts *GetOptions) (path string) {
 	return ""
 }
 
+const (
+	IncludeParam       = "include"
+	ExcludeParam       = "exclude"
+	PageParam          = "page"
+	PerPageParam       = "per_page"
+	SearchParam        = "search"
+	SortByParam        = "sort_by"
+	SortDirectionParam = "sort_direction"
+)
+
 // Encode generates a URL query string ("?foo=bar")
 func (g *GetOptions) Encode() string {
 	if g == nil {
 		return ""
 	}
 	v := url.Values{}
+	for k, val := range g.ArbitraryOpts {
+		v.Add(k, val)
+	}
+	// the names parameters will rewrite arbitrary options
 	if g.Includes != nil && len(g.Includes) > 0 {
-		v.Add("include", strings.Join(g.Includes, ","))
+		v.Add(IncludeParam, strings.Join(g.Includes, ","))
 	}
 	if g.Excludes != nil && len(g.Excludes) > 0 {
-		v.Add("exclude", strings.Join(g.Excludes, ","))
+		v.Add(ExcludeParam, strings.Join(g.Excludes, ","))
 	}
 	if g.Page != 0 {
-		v.Add("page", strconv.Itoa(g.Page))
+		v.Add(PageParam, strconv.Itoa(g.Page))
 	}
 	if g.PerPage != 0 {
-		v.Add("per_page", strconv.Itoa(g.PerPage))
+		v.Add(PerPageParam, strconv.Itoa(g.PerPage))
 	}
 	if g.Search != "" {
-		v.Add("search", g.Search)
+		v.Add(SearchParam, g.Search)
 	}
 	if g.SortBy != "" {
-		v.Add("sort_by", g.SortBy)
+		v.Add(SortByParam, g.SortBy)
 	}
 	if g.SortDirection != "" {
-		v.Add("sort_direction", string(g.SortDirection))
+		v.Add(SortDirectionParam, string(g.SortDirection))
 	}
 	return v.Encode()
 }

--- a/api_call_options.go
+++ b/api_call_options.go
@@ -37,8 +37,8 @@ type GetOptions struct {
 	// their `Href` field.
 	Excludes []string `url:"exclude,omitempty,comma"`
 
-	// Arbitrary params for API URL, used for arbitrary filters
-	ArbitraryOpts map[string]string `url:"-"`
+	// QueryParams for API URL, used for arbitrary filters
+	QueryParams map[string]string `url:"-"`
 
 	// Page is the page of results to retrieve for paginated result sets
 	Page int `url:"page,omitempty"`
@@ -111,16 +111,16 @@ func (g *GetOptions) CopyOrNew() *GetOptions {
 }
 
 func (g *GetOptions) Filter(key, value string) *GetOptions {
-	return g.AddOpt(key, value)
+	return g.AddParam(key, value)
 }
 
-// AddOpt adds key=value to URL path
-func (g *GetOptions) AddOpt(key, value string) *GetOptions {
+// AddParam adds key=value to URL path
+func (g *GetOptions) AddParam(key, value string) *GetOptions {
 	ret := g.CopyOrNew()
-	if ret.ArbitraryOpts == nil {
-		ret.ArbitraryOpts = map[string]string{}
+	if ret.QueryParams == nil {
+		ret.QueryParams = map[string]string{}
 	}
-	ret.ArbitraryOpts[key] = value
+	ret.QueryParams[key] = value
 	return ret
 }
 
@@ -185,7 +185,7 @@ func (g *GetOptions) Encode() string {
 		return ""
 	}
 	v := url.Values{}
-	for k, val := range g.ArbitraryOpts {
+	for k, val := range g.QueryParams {
 		v.Add(k, val)
 	}
 	// the names parameters will rewrite arbitrary options

--- a/plans_test.go
+++ b/plans_test.go
@@ -53,8 +53,6 @@ func TestAccPlansFilter(t *testing.T) {
 	if len(onDemandPlans) >= len(allPlans) {
 		t.Fatalf("filtering of plans listing might not be working")
 	}
-	log.Println(len(onDemandPlans), len(allPlans))
-
 }
 
 func TestAccPlansBasic(t *testing.T) {

--- a/plans_test.go
+++ b/plans_test.go
@@ -32,6 +32,31 @@ func plansInFacilities(t *testing.T, plans []Plan) {
 	}
 }
 
+func TestAccPlansFilter(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+
+	c, stopRecord := setup(t)
+	defer stopRecord()
+	opts := &ListOptions{Includes: []string{"available_in"}}
+
+	optsOnDemand := opts.Filter("deployment_type", "on_demand")
+
+	onDemandPlans, _, err := c.Plans.List(optsOnDemand)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allPlans, _, err := c.Plans.List(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onDemandPlans) >= len(allPlans) {
+		t.Fatalf("filtering of plans listing might not be working")
+	}
+	log.Println(len(onDemandPlans), len(allPlans))
+
+}
+
 func TestAccPlansBasic(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 


### PR DESCRIPTION
Fixes #289 

This PR adds support for passing arbitraty options to ListOptions (and all the aliased *Options). It also adds a Filter func wrapper which we can use to pass "filters".

```go
	opts := &ListOptions{Includes: []string{"available_in"}}

	optsOnDemand := opts.Filter("deployment_type", "on_demand")

	onDemandPlans, _, err := c.Plans.List(optsOnDemand)
	if err != nil {
		t.Fatal(err)
	}
```

@displague I was wondering if I should check if the keys of the passed filters don't collide with options that we use otherwise (page, include, ...). It could be done easily, but I don't know how to signal the error.

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>