### PR TITLE
optionalize DeviceCreateRequest hostname and billing_cycle to match API

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -380,14 +380,14 @@ type CPR struct {
 
 // DeviceCreateRequest type used to create an Equinix Metal device
 type DeviceCreateRequest struct {
-	Hostname              string     `json:"hostname"`
+	Hostname              string     `json:"hostname,omitempty"`
 	Plan                  string     `json:"plan"`
 	Facility              []string   `json:"facility,omitempty"`
 	Metro                 string     `json:"metro,omitempty"`
 	OS                    string     `json:"operating_system"`
-	BillingCycle          string     `json:"billing_cycle"`
+	BillingCycle          string     `json:"billing_cycle,omitempty"`
 	ProjectID             string     `json:"project_id"`
-	UserData              string     `json:"userdata"`
+	UserData              string     `json:"userdata,omitempty"`
 	Storage               *CPR       `json:"storage,omitempty"`
 	Tags                  []string   `json:"tags"`
 	Description           string     `json:"description,omitempty"`


### PR DESCRIPTION
Hostname and billing_cycle are optional. The following works:
```
curl \
   -H "X-Auth-Token: $METAL_AUTH_TOKEN" \
   -H "Content-type: application/json" \
   -d '{"operating_system":"$OS", "plan":"$PLAN","facility":"$FACILITY"}' \
    https://api.equinix.com/metal/v1/projects/$PROJECT_ID/devices
```
The values are computed and reported in the response:
```
{"id":"8a35cf0c-2205-4004-878d-ff8464b30cb1","short_id":"8a35cf0c",
"hostname":"8a35cf0c.packethost.net","description":null,
"tags":[],"image_url":null,"billing_cycle":"hourly", ...
```

By lightening the requirements, we make it easier to provision resources in Terraform and the Metal CLI, among other tools.