### PR TITLE
Add Metro support in metadata

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -113,6 +113,7 @@ type CurrentDevice struct {
 	Hostname   string                 `json:"hostname"`
 	IQN        string                 `json:"iqn"`
 	Plan       string                 `json:"plan"`
+	Metro      string                 `json:"metro"`
 	Facility   string                 `json:"facility"`
 	Tags       []string               `json:"tags"`
 	SSHKeys    []string               `json:"ssh_keys"`

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -36,6 +36,8 @@ func Test_Deserialization(t *testing.T) {
 
 	assert.Equal(t, "9307dc37-7f39-400b-9cd2-009087434a95", device.ID)
 	assert.Equal(t, "spcqvzylz6-worker-2409003", device.Hostname)
+	assert.Equal(t, "ewr1", device.Facility)
+	assert.Equal(t, "ny", device.Metro)
 
 	volumes := device.Volumes
 	assert.Equal(t, 1, len(volumes))

--- a/metadata/testdata/device.json
+++ b/metadata/testdata/device.json
@@ -13,6 +13,7 @@
   },
   "plan": "baremetal_1",
   "class": "c1.small.x86",
+  "metro": "ny",
   "facility": "ewr1",
   "tags": [],
   "ssh_keys": [


### PR DESCRIPTION
Metadata has `"metro"` in addition to `"facility"`. Added it, and added test as well.