### PR TITLE
Create UserLite Struct and add CreatedBy field in Device Struct

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -49,6 +49,7 @@ type Device struct {
 	Description         *string                `json:"description,omitempty"`
 	State               string                 `json:"state,omitempty"`
 	Created             string                 `json:"created_at,omitempty"`
+	CreatedBy           *UserLite              `json:"created_by,omitempty"`
 	Updated             string                 `json:"updated_at,omitempty"`
 	Locked              bool                   `json:"locked,omitempty"`
 	BillingCycle        string                 `json:"billing_cycle,omitempty"`

--- a/user.go
+++ b/user.go
@@ -68,6 +68,21 @@ type User struct {
 	Staff                 bool    `json:"staff,omitempty"`
 }
 
+// UserLite is an abbreviated listing of an Equinix Metal user
+type UserLite struct {
+	ID             string     `json:"id"`
+	ShortID        string     `json:"short_id"`
+	FirstName      string     `json:"first_name,omitempty"`
+	LastName       string     `json:"last_name,omitempty"`
+	FullName       string     `json:"full_name,omitempty"`
+	Email          string     `json:"email,omitempty"`
+	CreatedAt      *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt      *Timestamp `json:"updated_at,omitempty"`
+	Level          string     `json:"level,omitempty"`
+	AvatarThumbURL string     `json:"avatar_thumb_url,omitempty"`
+	URL            string     `json:"href,omitempty"`
+}
+
 // UserUpdateRequest struct for UserService.Update
 type UserUpdateRequest struct {
 	FirstName   *string      `json:"first_name,omitempty"`

--- a/user.go
+++ b/user.go
@@ -70,7 +70,7 @@ type User struct {
 
 // UserLite is an abbreviated listing of an Equinix Metal user
 type UserLite struct {
-        *Href `json:",inline"`
+	*Href          `json:",inline"`
 	ID             string     `json:"id"`
 	ShortID        string     `json:"short_id"`
 	FirstName      string     `json:"first_name,omitempty"`
@@ -81,7 +81,6 @@ type UserLite struct {
 	UpdatedAt      *Timestamp `json:"updated_at,omitempty"`
 	Level          string     `json:"level,omitempty"`
 	AvatarThumbURL string     `json:"avatar_thumb_url,omitempty"`
-	URL            string     `json:"href,omitempty"`
 }
 
 // UserUpdateRequest struct for UserService.Update

--- a/user.go
+++ b/user.go
@@ -70,6 +70,7 @@ type User struct {
 
 // UserLite is an abbreviated listing of an Equinix Metal user
 type UserLite struct {
+        *Href `json:",inline"`
 	ID             string     `json:"id"`
 	ShortID        string     `json:"short_id"`
 	FirstName      string     `json:"first_name,omitempty"`


### PR DESCRIPTION
metal-cli is unable to display the created_by field on devices. This is due to packngo not having that field in the device struct. This PR adds the created_by field to the device struct and also adds a new UserLite struct that is used for that created_by field. 