### PR TITLE
add IPReservationStatus related definitions

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -69,6 +69,19 @@ type ParentBlock struct {
 	Href    *string `json:"href,omitempty"`
 }
 
+type IPReservationState string
+
+const (
+	// IPReservationStatePending fixed string representation of pending
+	IPReservationStatePending IPReservationState = "pending"
+
+	// IPReservationStateCreated fixed string representation of created
+	IPReservationStateCreated IPReservationState = "created"
+
+	// IPReservationStateDenied fixed string representation of denied
+	IPReservationStateDenied IPReservationState = "denied"
+)
+
 // IPAddressReservation is created when user sends IP reservation request for a project (considering it's within quota).
 type IPAddressReservation struct {
 	IpAddressCommon
@@ -77,6 +90,7 @@ type IPAddressReservation struct {
 	Available   string                 `json:"available"`
 	Addon       bool                   `json:"addon"`
 	Bill        bool                   `json:"bill"`
+	State       IPReservationState     `json:"state"`
 	Description *string                `json:"details"`
 }
 


### PR DESCRIPTION
Adds the missing Status field and enum values

This will be necessary for https://github.com/equinix/terraform-provider-metal/issues/135