### PR TITLE
Add VRF Support (not-GA)

### DIFF
--- a/devices_test.go
+++ b/devices_test.go
@@ -8,33 +8,31 @@ import (
 	"time"
 )
 
-var (
-	// managementIPS is a block of public ipv4 and ipv6, with private ipv4. all
-	// with management enabled. This is standard in Layer3 configurations.
-	managementIPS = []*IPAddressAssignment{
-		{
-			IpAddressCommon: IpAddressCommon{
-				Management:    true,
-				AddressFamily: 4,
-				Public:        true,
-			},
+// managementIPS is a block of public ipv4 and ipv6, with private ipv4. all
+// with management enabled. This is standard in Layer3 configurations.
+var managementIPS = []*IPAddressAssignment{
+	{
+		IpAddressCommon: IpAddressCommon{
+			Management:    true,
+			AddressFamily: 4,
+			Public:        true,
 		},
-		{
-			IpAddressCommon: IpAddressCommon{
-				Management:    true,
-				AddressFamily: 6,
-				Public:        true,
-			},
+	},
+	{
+		IpAddressCommon: IpAddressCommon{
+			Management:    true,
+			AddressFamily: 6,
+			Public:        true,
 		},
-		{
-			IpAddressCommon: IpAddressCommon{
-				Management:    true,
-				AddressFamily: 4,
-				Public:        false,
-			},
+	},
+	{
+		IpAddressCommon: IpAddressCommon{
+			Management:    true,
+			AddressFamily: 4,
+			Public:        false,
 		},
-	}
-)
+	},
+}
 
 func waitDeviceActive(t *testing.T, c *Client, id string) *Device {
 	// 15 minutes = 180 * 5sec-retry
@@ -241,7 +239,6 @@ func TestAccDeviceBasic(t *testing.T) {
 		if ipa.Public && (ipa.AddressFamily == 4) {
 			if ipa.Address != networkInfo.PublicIPv4 {
 				t.Fatalf("strange public IPv4 from GetNetworkInfo, should be %s, is %s", ipa.Address, networkInfo.PublicIPv4)
-
 			}
 		}
 	}
@@ -253,7 +250,6 @@ func TestAccDeviceBasic(t *testing.T) {
 	if len(dl) != 1 {
 		t.Fatalf("Device List should contain exactly one device, was: %v", dl)
 	}
-
 }
 
 func TestAccDevicePXE(t *testing.T) {
@@ -354,7 +350,7 @@ func TestAccDeviceAssignGlobalIP(t *testing.T) {
 		Description: "packngo test",
 	}
 
-	reservation, _, err := c.ProjectIPs.Request(projectID, &req)
+	reservation, _, err := c.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +386,6 @@ func TestAccDeviceAssignGlobalIP(t *testing.T) {
 	if reservation.Assignments[0].Href != assignment.Href {
 		t.Fatalf("assignment %s should be listed in reservation resource %s",
 			assignment.Href, reservation)
-
 	}
 
 	for _, ipa := range d.Network {
@@ -452,7 +447,7 @@ func TestAccDeviceCreateWithReservedIP(t *testing.T) {
 		Facility:    &fac,
 	}
 
-	reservation, _, err := c.ProjectIPs.Request(projectID, &req)
+	reservation, _, err := c.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,8 +463,10 @@ func TestAccDeviceCreateWithReservedIP(t *testing.T) {
 		IPAddresses: []IPAddressCreateRequest{
 			// NOTE: only one public IPv4 entry is allowed here
 			{AddressFamily: 4, Public: false},
-			{AddressFamily: 4, Public: true,
-				Reservations: []string{reservation.ID}, CIDR: 31},
+			{
+				AddressFamily: 4, Public: true,
+				Reservations: []string{reservation.ID}, CIDR: 31,
+			},
 		},
 	}
 
@@ -525,7 +522,7 @@ func TestAccDeviceAssignIP(t *testing.T) {
 		Facility:    &fac,
 	}
 
-	reservation, _, err := c.ProjectIPs.Request(projectID, &req)
+	reservation, _, err := c.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -577,7 +574,6 @@ func TestAccDeviceAssignIP(t *testing.T) {
 	if reservation.Assignments[0].Href != assignment.Href {
 		t.Fatalf("assignment %s should be listed in reservation resource %s",
 			assignment.Href, reservation)
-
 	}
 
 	for _, ipa := range d.Network {
@@ -1075,7 +1071,6 @@ func TestAccDeviceCreateFacilities(t *testing.T) {
 	if !placedInRequestedFacility {
 		t.Fatal("Did not properly assign facility to device")
 	}
-
 }
 
 func TestAccDeviceIPAddresses(t *testing.T) {
@@ -1134,7 +1129,6 @@ func TestAccDeviceIPAddresses(t *testing.T) {
 	if len(dl) != 1 {
 		t.Fatalf("Device List should contain exactly one device, was: %v", dl)
 	}
-
 }
 
 func TestDevice_NumOfBonds(t *testing.T) {
@@ -1191,7 +1185,8 @@ func TestDevice_GetNetworkType(t *testing.T) {
 	}{
 		{
 			name: "GetNetworkType_bm0_provisioning", // t1.small.x86
-			fields: fields{Plan: &Plan{Slug: "baremetal_0"},
+			fields: fields{
+				Plan: &Plan{Slug: "baremetal_0"},
 				NetworkPorts: []Port{{
 					Type: "NetworkBondPort",
 					Name: "bond0",
@@ -1217,7 +1212,8 @@ func TestDevice_GetNetworkType(t *testing.T) {
 		},
 		{
 			name: "GetNetworkType_bm0_ready", // t1.small.x86 post-provision
-			fields: fields{Plan: &Plan{Slug: "baremetal_0"},
+			fields: fields{
+				Plan:    &Plan{Slug: "baremetal_0"},
 				Network: managementIPS,
 				NetworkPorts: []Port{{
 					Type: "NetworkBondPort",
@@ -1244,7 +1240,8 @@ func TestDevice_GetNetworkType(t *testing.T) {
 		},
 		{
 			name: "GetNetworkType_bm1", // c1.small.x86
-			fields: fields{Plan: &Plan{Slug: "baremetal_1"},
+			fields: fields{
+				Plan: &Plan{Slug: "baremetal_1"},
 				NetworkPorts: []Port{{
 					Type: "NetworkBondPort",
 					Name: "bond0",
@@ -1264,12 +1261,14 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Data: PortData{
 						Bonded: true,
 					},
-				}}},
+				}},
+			},
 			want: NetworkTypeL3,
 		},
 		{
 			name: "GetNetworkType_bm1e_provisioning", // x1.small.x86
-			fields: fields{Plan: &Plan{Slug: "baremetal_1e"},
+			fields: fields{
+				Plan:    &Plan{Slug: "baremetal_1e"},
 				Network: managementIPS,
 				NetworkPorts: []Port{{
 					Type: "NetworkBondPort",
@@ -1290,12 +1289,14 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Data: PortData{
 						Bonded: true,
 					},
-				}}},
+				}},
+			},
 			want: NetworkTypeHybrid,
 		},
 		{
 			name: "GetNetworkType_bm1e_provisioning", // x1.small.x86
-			fields: fields{Plan: &Plan{Slug: "baremetal_1e"},
+			fields: fields{
+				Plan: &Plan{Slug: "baremetal_1e"},
 				NetworkPorts: []Port{{
 					Type: "NetworkBondPort",
 					Name: "bond0",
@@ -1315,7 +1316,8 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Data: PortData{
 						Bonded: false,
 					},
-				}}},
+				}},
+			},
 			want: NetworkTypeHybrid,
 		},
 		{
@@ -1414,53 +1416,56 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Data: PortData{
 						Bonded: true,
 					},
-				}}},
+				}},
+			},
 			want: NetworkTypeL3,
 		},
 		{
 			name: "GetNetworkType_FourNics_Bonded_WithManagement", // n2-xlarge l3
 			fields: fields{
 				Network: managementIPS,
-				NetworkPorts: []Port{{
-					Type: "NetworkBondPort",
-					Name: "bond0",
-					Data: PortData{
-						Bonded: true,
-					},
-					NetworkType: "layer3",
-				}, {
-					Type: "NetworkBondPort",
-					Name: "bond1",
-					Data: PortData{
-						Bonded: true,
-					},
-					NetworkType: "layer3",
-				}, {
-					Type: "NetworkPort",
-					Name: "eth0",
-					Data: PortData{
-						Bonded: true,
-					},
-				}, {
-					Type: "NetworkPort",
-					Name: "eth1",
-					Data: PortData{
-						Bonded: true,
-					},
-				}, {
-					Type: "NetworkPort",
-					Name: "eth2",
-					Data: PortData{
-						Bonded: true,
-					},
-				}, {
-					Type: "NetworkPort",
-					Name: "eth3",
-					Data: PortData{
-						Bonded: true,
+				NetworkPorts: []Port{
+					{
+						Type: "NetworkBondPort",
+						Name: "bond0",
+						Data: PortData{
+							Bonded: true,
+						},
+						NetworkType: "layer3",
+					}, {
+						Type: "NetworkBondPort",
+						Name: "bond1",
+						Data: PortData{
+							Bonded: true,
+						},
+						NetworkType: "layer3",
+					}, {
+						Type: "NetworkPort",
+						Name: "eth0",
+						Data: PortData{
+							Bonded: true,
+						},
+					}, {
+						Type: "NetworkPort",
+						Name: "eth1",
+						Data: PortData{
+							Bonded: true,
+						},
+					}, {
+						Type: "NetworkPort",
+						Name: "eth2",
+						Data: PortData{
+							Bonded: true,
+						},
+					}, {
+						Type: "NetworkPort",
+						Name: "eth3",
+						Data: PortData{
+							Bonded: true,
+						},
 					},
 				},
-				}},
+			},
 			want: NetworkTypeL3,
 		},
 
@@ -1468,46 +1473,48 @@ func TestDevice_GetNetworkType(t *testing.T) {
 			name: "GetNetworkType_FourNics_Bonded_NoIPs", // n2-xlarge l2-bonded
 			fields: fields{
 				Network: []*IPAddressAssignment{},
-				NetworkPorts: []Port{{
-					Type: "NetworkBondPort",
-					Name: "bond0",
-					Data: PortData{
-						Bonded: true,
-					},
-					NetworkType: "layer2-bonded",
-				}, {
-					Type: "NetworkBondPort",
-					Name: "bond1",
-					Data: PortData{
-						Bonded: true,
-					},
-					NetworkType: "layer2-bonded",
-				}, {
-					Type: "NetworkPort",
-					Name: "eth0",
-					Data: PortData{
-						Bonded: true,
-					},
-				}, {
-					Type: "NetworkPort",
-					Name: "eth1",
-					Data: PortData{
-						Bonded: true,
-					},
-				}, {
-					Type: "NetworkPort",
-					Name: "eth2",
-					Data: PortData{
-						Bonded: true,
-					},
-				}, {
-					Type: "NetworkPort",
-					Name: "eth3",
-					Data: PortData{
-						Bonded: true,
+				NetworkPorts: []Port{
+					{
+						Type: "NetworkBondPort",
+						Name: "bond0",
+						Data: PortData{
+							Bonded: true,
+						},
+						NetworkType: "layer2-bonded",
+					}, {
+						Type: "NetworkBondPort",
+						Name: "bond1",
+						Data: PortData{
+							Bonded: true,
+						},
+						NetworkType: "layer2-bonded",
+					}, {
+						Type: "NetworkPort",
+						Name: "eth0",
+						Data: PortData{
+							Bonded: true,
+						},
+					}, {
+						Type: "NetworkPort",
+						Name: "eth1",
+						Data: PortData{
+							Bonded: true,
+						},
+					}, {
+						Type: "NetworkPort",
+						Name: "eth2",
+						Data: PortData{
+							Bonded: true,
+						},
+					}, {
+						Type: "NetworkPort",
+						Name: "eth3",
+						Data: PortData{
+							Bonded: true,
+						},
 					},
 				},
-				}},
+			},
 			want: NetworkTypeL2Bonded,
 		},
 		{
@@ -1600,7 +1607,8 @@ func TestDevice_GetNetworkType(t *testing.T) {
 					Data: PortData{
 						Bonded: false,
 					},
-				}}},
+				}},
+			},
 			want: NetworkTypeHybrid,
 		},
 	}
@@ -1679,7 +1687,6 @@ func TestAccDeviceMetroBasic(t *testing.T) {
 		if ipa.Public && (ipa.AddressFamily == 4) {
 			if ipa.Address != networkInfo.PublicIPv4 {
 				t.Fatalf("strange public IPv4 from GetNetworkInfo, should be %s, is %s", ipa.Address, networkInfo.PublicIPv4)
-
 			}
 		}
 	}
@@ -1691,7 +1698,6 @@ func TestAccDeviceMetroBasic(t *testing.T) {
 	if len(dl) != 1 {
 		t.Fatalf("Device List should contain exactly one device, was: %v", dl)
 	}
-
 }
 
 func TestDatapoint_UnmarshalJSON(t *testing.T) {
@@ -1710,7 +1716,8 @@ func TestDatapoint_UnmarshalJSON(t *testing.T) {
 			Rate: func(f float64) *float64 {
 				return &f
 			}(1),
-			When: Timestamp{Time: time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)}},
+			When: Timestamp{Time: time.Date(2021, time.Month(1), 1, 0, 0, 0, 0, time.UTC)},
+		},
 		wantErr: false,
 	}}
 

--- a/ip.go
+++ b/ip.go
@@ -38,8 +38,11 @@ type DeviceIPService interface {
 type ProjectIPService interface {
 	Get(reservationID string, getOpt *GetOptions) (*IPAddressReservation, *Response, error)
 	List(projectID string, opts *ListOptions) ([]IPAddressReservation, *Response, error)
+	// Deprecated Use Create instead of Request
+	Request(projectID string, ipReservationReq *IPReservationRequest) (*IPAddressReservation, *Response, error)
 	Create(projectID string, ipReservationReq *IPReservationCreateRequest) (*IPAddressReservation, *Response, error)
 	Delete(ipReservationID string) (*Response, error)
+	// Deprecated Use Delete instead of Remove
 	Remove(ipReservationID string) (*Response, error)
 	Update(assignmentID string, updateRequest *IPAddressUpdateRequest, opt *GetOptions) (*IPAddressReservation, *Response, error)
 	AvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error)

--- a/ip.go
+++ b/ip.go
@@ -1,8 +1,8 @@
 package packngo
 
 import (
-	"fmt"
 	"path"
+	"strconv"
 )
 
 const ipBasePath = "/ips"
@@ -371,7 +371,13 @@ func (i *ProjectIPServiceOp) AvailableAddresses(ipReservationID string, r *Avail
 	if validateErr := ValidateUUID(ipReservationID); validateErr != nil {
 		return nil, nil, validateErr
 	}
-	apiPathQuery := fmt.Sprintf("%s/%s/available?cidr=%d", ipBasePath, ipReservationID, r.CIDR)
+
+	opts := &GetOptions{}
+	opts.Filter("cidr", strconv.Itoa(r.CIDR))
+
+	endpointPath := path.Join(ipBasePath, ipReservationID, "available")
+	apiPathQuery := opts.WithQuery(endpointPath)
+
 	ar := new(AvailableResponse)
 
 	resp, err := i.client.DoRequest("GET", apiPathQuery, r, ar)

--- a/ip_test.go
+++ b/ip_test.go
@@ -38,7 +38,7 @@ func TestAccPublicIPReservation(t *testing.T) {
 		FailOnApprovalRequired: true,
 	}
 
-	res, _, err := c.ProjectIPs.Request(projectID, &req)
+	res, _, err := c.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestAccGlobalIPReservation(t *testing.T) {
 		Description: description,
 	}
 
-	res, _, err := c.ProjectIPs.Request(projectID, &req)
+	res, _, err := c.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestAccPublicIPReservationFailFast(t *testing.T) {
 		FailOnApprovalRequired: true,
 	}
 
-	_, resp, err := c.ProjectIPs.Request(projectID, &req)
+	_, resp, err := c.ProjectIPs.Create(projectID, &req)
 	if err == nil {
 		t.Fatal("should have had an error 422")
 	}
@@ -269,7 +269,7 @@ func TestAccPublicMetroIPReservation(t *testing.T) {
 		FailOnApprovalRequired: true,
 	}
 
-	res, _, err := c.ProjectIPs.Request(projectID, &req)
+	res, _, err := c.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metal_gateway.go
+++ b/metal_gateway.go
@@ -29,6 +29,7 @@ type MetalGateway struct {
 	Href           string                `json:"href"`
 	CreatedAt      string                `json:"created_at,omitempty"`
 	UpdatedAt      string                `json:"updated_at,omitempty"`
+	VRF            *VRF                  `json:"vrf,omitempty"`
 }
 
 // MetalGatewayLite struct representation of a Metal Gateway
@@ -76,13 +77,17 @@ func (s *MetalGatewayServiceOp) List(projectID string, opts *ListOptions) (metal
 		}
 		return
 	}
-
 }
 
 type MetalGatewayCreateRequest struct {
-	VirtualNetworkID      string `json:"virtual_network_id"`
-	IPReservationID       string `json:"ip_reservation_id,omitempty"`
-	PrivateIPv4SubnetSize int    `json:"private_ipv4_subnet_size,omitempty"`
+	// VirtualNetworkID virtual network UUID.
+	VirtualNetworkID string `json:"virtual_network_id"`
+
+	// IPReservationID (optional) IP Reservation UUID (Public or VRF). Required for VRF.
+	IPReservationID string `json:"ip_reservation_id,omitempty"`
+
+	// PrivateIPv4SubnetSize (optional) Power of 2 between 8 and 128 (8, 16, 32, 64, 128). Invalid for VRF.
+	PrivateIPv4SubnetSize int `json:"private_ipv4_subnet_size,omitempty"`
 }
 
 func (s *MetalGatewayServiceOp) Get(metalGatewayID string, opts *GetOptions) (*MetalGateway, *Response, error) {

--- a/metal_gateway_test.go
+++ b/metal_gateway_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestAccMetalGatewaySubnetSize(t *testing.T) {
-
 	skipUnlessAcceptanceTestsAllowed(t)
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
@@ -59,7 +58,6 @@ func TestAccMetalGatewaySubnetSize(t *testing.T) {
 }
 
 func TestAccMetalGatewayExistingReservation(t *testing.T) {
-
 	skipUnlessAcceptanceTestsAllowed(t)
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
@@ -84,7 +82,7 @@ func TestAccMetalGatewayExistingReservation(t *testing.T) {
 		Metro:                  &metro,
 		FailOnApprovalRequired: true,
 	}
-	ipRes, _, err := c.ProjectIPs.Request(projectID, &ipcr)
+	ipRes, _, err := c.ProjectIPs.Create(projectID, &ipcr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packngo.go
+++ b/packngo.go
@@ -395,6 +395,7 @@ func NewClientWithBaseURL(consumerToken string, apiKey string, httpClient *http.
 	c.VirtualCircuits = &VirtualCircuitServiceOp{client: c}
 	c.VolumeAttachments = &VolumeAttachmentServiceOp{client: c}
 	c.Volumes = &VolumeServiceOp{client: c}
+	c.VRFs = &VRFServiceOp{client: c}
 	c.VLANAssignments = &VLANAssignmentServiceOp{client: c}
 	c.debug = os.Getenv(debugEnvVar) != ""
 

--- a/packngo.go
+++ b/packngo.go
@@ -125,6 +125,7 @@ type Client struct {
 	VLANAssignments        VLANAssignmentService
 	VolumeAttachments      VolumeAttachmentService
 	Volumes                VolumeService
+	VRFs                   VRFService
 
 	// DevicePorts
 	//

--- a/virtualcircuits.go
+++ b/virtualcircuits.go
@@ -2,27 +2,29 @@ package packngo
 
 import "path"
 
+type VCStatus string
+
 const (
 	virtualCircuitBasePath = "/virtual-circuits"
 
 	// VC is being create but not ready yet
-	VCStatusPending = "pending"
+	VCStatusPending VCStatus = "pending"
 
 	// VC is ready with a VLAN
-	VCStatusActive = "active"
+	VCStatusActive VCStatus = "active"
 
 	// VC is ready without a VLAN
-	VCStatusWaiting = "waiting_on_customer_vlan"
+	VCStatusWaiting VCStatus = "waiting_on_customer_vlan"
 
 	// VC is being deleted
-	VCStatusDeleting = "deleting"
+	VCStatusDeleting VCStatus = "deleting"
 
 	// not sure what the following states mean, or whether they exist
 	// someone from the API side could check
-	VCStatusActivating         = "activating"
-	VCStatusDeactivating       = "deactivating"
-	VCStatusActivationFailed   = "activation_failed"
-	VCStatusDeactivationFailed = "dactivation_failed"
+	VCStatusActivating         VCStatus = "activating"
+	VCStatusDeactivating       VCStatus = "deactivating"
+	VCStatusActivationFailed   VCStatus = "activation_failed"
+	VCStatusDeactivationFailed VCStatus = "dactivation_failed"
 )
 
 type VirtualCircuitService interface {
@@ -44,11 +46,32 @@ type VCUpdateRequest struct {
 }
 
 type VCCreateRequest struct {
-	VirtualNetworkID string   `json:"vnid"`
-	NniVLAN          int      `json:"nni_vlan,omitempty"`
-	Name             string   `json:"name,omitempty"`
-	Description      string   `json:"description,omitempty"`
-	Tags             []string `json:"tags,omitempty"`
+	// VirtualNetworkID of the Virtual Network to connect to the Virtual Circuit (required when VRFID is not specified)
+	VirtualNetworkID string `json:"vnid,omitempty"`
+	// VRFID of the VRF to connect to the Virtual Circuit (required when VirtualNetworkID is not specified)
+	VRFID string `json:"vrf_id,omitempty"`
+	// PeerASN (optional, required with VRFID) The BGP ASN of the device the switch will peer with. Can be the used across several VCs, but cannot be the same as the local_asn.
+	PeerASN int `json:"peer_asn,omitempty"`
+	// Subnet (Required for VRF) A subnet from one of the IP blocks associated with the VRF that we
+	// will help create an IP reservation for. Can only be either a /30 or /31.
+	//  * For a /31 block, it will only have two IP addresses, which will be used for the metal_ip and customer_ip.
+	//  * For a /30 block, it will have four IP
+	// addresses, but the first and last IP addresses are not usable. We will
+	// default to the first usable IP address for the metal_ip.
+	Subnet string `json:"subnet,omitempty"`
+	// MetalIP (optional, required with VRFID) The IP address that’s set as “our” IP that is
+	// configured on the rack_local_vlan SVI. Will default to the first usable
+	// IP in the subnet.
+	MetalIP string `json:"metal_ip,omitempty"`
+	// CustomerIP (optional, requires VRFID) The IP address set as the customer IP which the CSR
+	// switch will peer with. Will default to the other usable IP in the subnet.
+	CustomerIP string `json:"customer_ip,omitempty"`
+	// MD5 (optional, requires VRFID) The password that can be set for the VRF BGP peer
+	MD5         string   `json:"md5,omitempty"`
+	NniVLAN     int      `json:"nni_vlan,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
 
 	// Speed is a bps representation of the VirtualCircuit throughput. This is informational only, the field is a user-controlled description of the speed. It may be presented as a whole number with a bps, mpbs, or gbps suffix (or the respective initial).
 	Speed string `json:"speed,omitempty"`
@@ -68,7 +91,7 @@ type VirtualCircuit struct {
 	Name           string          `json:"name,omitempty"`
 	Description    string          `json:"description,omitempty"`
 	Speed          string          `json:"speed,omitempty"`
-	Status         string          `json:"status,omitempty"`
+	Status         VCStatus        `json:"status,omitempty"`
 	VNID           int             `json:"vnid,omitempty"`
 	NniVNID        int             `json:"nni_vnid,omitempty"`
 	NniVLAN        int             `json:"nni_vlan,omitempty"`
@@ -76,6 +99,31 @@ type VirtualCircuit struct {
 	Port           *ConnectionPort `json:"port,omitempty"`
 	VirtualNetwork *VirtualNetwork `json:"virtual_network,omitempty"`
 	Tags           []string        `json:"tags,omitempty"`
+	// VRF connected to the Virtual Circuit
+	VRF *VRF `json:"vrf,omitempty"`
+
+	// PeerASN (optional, required with VRFID) The BGP ASN of the device the switch will peer with. Can be the used across several VCs, but cannot be the same as the local_asn.
+	PeerASN int `json:"peer_asn,omitempty"`
+
+	// Subnet (returned with VRF) A subnet from one of the IP blocks associated with the VRF that we
+	// will help create an IP reservation for. Can only be either a /30 or /31.
+	//  * For a /31 block, it will only have two IP addresses, which will be used for the metal_ip and customer_ip.
+	//  * For a /30 block, it will have four IP
+	// addresses, but the first and last IP addresses are not usable. We will
+	// default to the first usable IP address for the metal_ip.
+	Subnet string `json:"subnet,omitempty"`
+
+	// MetalIP (returned with VRF) The IP address that’s set as “our” IP that is
+	// configured on the rack_local_vlan SVI. Will default to the first usable
+	// IP in the subnet.
+	MetalIP string `json:"metal_ip,omitempty"`
+
+	// CustomerIP (returned with VRF) The IP address set as the customer IP which the CSR
+	// switch will peer with. Will default to the other usable IP in the subnet.
+	CustomerIP string `json:"customer_ip,omitempty"`
+
+	// MD5 (returned with VRF) The password that can be set for the VRF BGP peer
+	MD5 string `json:"md5,omitempty"`
 }
 
 func (s *VirtualCircuitServiceOp) do(method, apiPathQuery string, req interface{}) (*VirtualCircuit, *Response, error) {

--- a/virtualcircuits_test.go
+++ b/virtualcircuits_test.go
@@ -22,7 +22,7 @@ func removeVirtualCircuit(t *testing.T, c *Client, id string) {
 	}
 }
 
-func waitVirtualCircuitStatus(t *testing.T, c *Client, id, status string, errStati []string) (*VirtualCircuit, error) {
+func waitVirtualCircuitStatus(t *testing.T, c *Client, id string, status VCStatus, errStati []string) (*VirtualCircuit, error) {
 	// 15 minutes = 180 * 5sec-retry
 	for i := 0; i < 180; i++ {
 		<-time.After(5 * time.Second)
@@ -33,7 +33,7 @@ func waitVirtualCircuitStatus(t *testing.T, c *Client, id, status string, errSta
 		if vc.Status == status {
 			return vc, nil
 		}
-		if contains(errStati, vc.Status) {
+		if contains(errStati, string(vc.Status)) {
 			return nil, fmt.Errorf("VirtualCircuit %s ended up in status %s", vc.ID, vc.Status)
 		}
 	}
@@ -97,7 +97,7 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 	defer removeVirtualCircuit(t, c, vc.ID)
 
 	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusActive,
-		[]string{VCStatusActivationFailed})
+		[]string{string(VCStatusActivationFailed)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 	defer removeVirtualCircuit(t, c, vc2.ID)
 
 	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, VCStatusActive,
-		[]string{VCStatusActivationFailed})
+		[]string{string(VCStatusActivationFailed)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,17 +131,16 @@ func TestAccVirtualCircuitDedicated(t *testing.T) {
 	}
 
 	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusWaiting,
-		[]string{VCStatusDeactivationFailed})
+		[]string{string(VCStatusDeactivationFailed)})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	_, err = waitVirtualCircuitStatus(t, c, vc2.ID, VCStatusWaiting,
-		[]string{VCStatusDeactivationFailed})
+		[]string{string(VCStatusDeactivationFailed)})
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 // this test needs an existing Shared Connection. Pass the ID in env var
@@ -176,7 +175,7 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 			t.Fatal(err)
 		}
 		_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusWaiting,
-			[]string{VCStatusDeactivationFailed})
+			[]string{string(VCStatusDeactivationFailed)})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -206,7 +205,7 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusActive,
-		[]string{VCStatusActivationFailed})
+		[]string{string(VCStatusActivationFailed)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,9 +231,8 @@ func TestAccVirtualCircuitShared(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = waitVirtualCircuitStatus(t, c, vc.ID, VCStatusWaiting,
-		[]string{VCStatusDeactivationFailed})
+		[]string{string(VCStatusDeactivationFailed)})
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }

--- a/vrf.go
+++ b/vrf.go
@@ -48,6 +48,23 @@ type VRFCreateRequest struct {
 	IPBlocks []string `json:"ip_blocks,omitempty"`
 }
 
+type VRFUpdateRequest struct {
+	// Name is the name of the VRF. It must be unique per project.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the VRF to be created.
+	Description *string `json:"description,omitempty"`
+
+	// LocalASN is the ASN of the local network.
+	LocalASN *int `json:"local_asn,omitempty"`
+
+	// IPBlocks is a list of all IPv4 and IPv6 Ranges that will be available to
+	// BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of
+	// /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must
+	// not overlap other ranges within the VRF.
+	IPBlocks *[]string `json:"ip_blocks,omitempty"`
+}
+
 type VRFServiceOp struct {
 	client *Client
 }
@@ -110,6 +127,25 @@ func (s *VRFServiceOp) Create(projectID string, input *VRFCreateRequest) (*VRF, 
 	}
 
 	return output, resp, nil
+}
+
+// Update updates an existing VRF
+func (s *VRFServiceOp) Update(vrfID string, updateRequest *VRFUpdateRequest) (*VRF, *Response, error) {
+	if validateErr := ValidateUUID(vrfID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	opts := &GetOptions{}
+	endpointPath := path.Join(vrfBasePath, vrfID)
+	apiPathQuery := opts.WithQuery(endpointPath)
+
+	vrf := new(VRF)
+
+	resp, err := s.client.DoRequest("PUT", apiPathQuery, updateRequest, vrf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vrf, resp, err
 }
 
 func (s *VRFServiceOp) Delete(vrfID string) (*Response, error) {

--- a/vrf.go
+++ b/vrf.go
@@ -1,0 +1,127 @@
+package packngo
+
+import (
+	"path"
+)
+
+const (
+	vrfBasePath = "/vrfs"
+)
+
+type VRFService interface {
+	List(projectID string, opts *ListOptions) ([]VRF, *Response, error)
+	Create(projectID string, input *VRFCreateRequest) (*VRF, *Response, error)
+	Get(vrfID string, opts *GetOptions) (*VRF, *Response, error)
+	Delete(vrfID string) (*Response, error)
+}
+
+type VRF struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	LocalASN    int      `json:"local_asn,omitempty"`
+	IPRanges    []string `json:"ip_ranges,omitempty"`
+	Project     *Project `json:"project,omitempty"`
+	Metro       *Metro   `json:"metro,omitempty"`
+	Href        string   `json:"href"`
+	CreatedAt   string   `json:"created_at,omitempty"`
+	UpdatedAt   string   `json:"updated_at,omitempty"`
+}
+
+type VRFCreateRequest struct {
+	//  Metro id or code
+	Metro string `json:"metro"`
+
+	// Name is the name of the VRF. It must be unique per project.
+	Name string `json:"name"`
+
+	// Description of the VRF to be created.
+	Description string `json:"description"`
+
+	// LocalASN is the ASN of the local network.
+	LocalASN int `json:"local_asn,omitempty"`
+
+	// IPBlocks is a list of all IPv4 and IPv6 Ranges that will be available to
+	// BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of
+	// /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must
+	// not overlap other ranges within the VRF.
+	IPBlocks []string `json:"ip_blocks,omitempty"`
+}
+
+type VRFServiceOp struct {
+	client *Client
+}
+
+func (s *VRFServiceOp) List(projectID string, opts *ListOptions) (vrfs []VRF, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	type vrfsRoot struct {
+		VRFs []VRF `json:"vrfs"`
+		Meta meta  `json:"meta"`
+	}
+
+	endpointPath := path.Join(projectBasePath, projectID, vrfBasePath)
+	apiPathQuery := opts.WithQuery(endpointPath)
+
+	for {
+		subset := new(vrfsRoot)
+
+		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, subset)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		vrfs = append(vrfs, subset.VRFs...)
+
+		if apiPathQuery = nextPage(subset.Meta, opts); apiPathQuery != "" {
+			continue
+		}
+		return
+	}
+}
+
+func (s *VRFServiceOp) Get(vrfID string, opts *GetOptions) (*VRF, *Response, error) {
+	if validateErr := ValidateUUID(vrfID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	endpointPath := path.Join(vrfBasePath, vrfID)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	metalGateway := new(VRF)
+
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, metalGateway)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return metalGateway, resp, err
+}
+
+func (s *VRFServiceOp) Create(projectID string, input *VRFCreateRequest) (*VRF, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	apiPath := path.Join(projectBasePath, projectID, vrfBasePath)
+	output := new(VRF)
+
+	resp, err := s.client.DoRequest("POST", apiPath, input, output)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return output, resp, nil
+}
+
+func (s *VRFServiceOp) Delete(vrfID string) (*Response, error) {
+	if validateErr := ValidateUUID(vrfID); validateErr != nil {
+		return nil, validateErr
+	}
+	apiPath := path.Join(vrfBasePath, vrfID)
+
+	resp, err := s.client.DoRequest("DELETE", apiPath, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/vrf.go
+++ b/vrf.go
@@ -11,6 +11,7 @@ const (
 type VRFService interface {
 	List(projectID string, opts *ListOptions) ([]VRF, *Response, error)
 	Create(projectID string, input *VRFCreateRequest) (*VRF, *Response, error)
+	Update(vrfID string, update *VRFUpdateRequest) (*VRF, *Response, error)
 	Get(vrfID string, opts *GetOptions) (*VRF, *Response, error)
 	ListIPs(vrfID string, opts *GetOptions) ([]IPAddressReservation, *Response, error)
 	Delete(vrfID string) (*Response, error)

--- a/vrf.go
+++ b/vrf.go
@@ -12,6 +12,7 @@ type VRFService interface {
 	List(projectID string, opts *ListOptions) ([]VRF, *Response, error)
 	Create(projectID string, input *VRFCreateRequest) (*VRF, *Response, error)
 	Get(vrfID string, opts *GetOptions) (*VRF, *Response, error)
+	ListIPs(vrfID string, opts *GetOptions) ([]IPAddressReservation, *Response, error)
 	Delete(vrfID string) (*Response, error)
 }
 
@@ -96,6 +97,28 @@ func (s *VRFServiceOp) List(projectID string, opts *ListOptions) (vrfs []VRF, re
 		}
 		return
 	}
+}
+
+func (s *VRFServiceOp) ListIPs(vrfID string, opts *ListOptions) (ips []IPAddressReservation, resp *Response, err error) {
+	if validateErr := ValidateUUID(vrfID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	endpointPath := path.Join(vrfBasePath, vrfID, ipBasePath)
+	apiPathQuery := opts.WithQuery(endpointPath)
+
+	// ipList represents collection of IP Address reservations
+	type ipList struct {
+		IPs []IPAddressReservation `json:"ip_addresses,omitempty"`
+	}
+
+	results := new(ipList)
+
+	resp, err = s.client.DoRequest("GET", apiPathQuery, nil, results)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return results.IPs, resp, err
 }
 
 func (s *VRFServiceOp) Get(vrfID string, opts *GetOptions) (*VRF, *Response, error) {

--- a/vrf.go
+++ b/vrf.go
@@ -42,11 +42,11 @@ type VRFCreateRequest struct {
 	// LocalASN is the ASN of the local network.
 	LocalASN int `json:"local_asn,omitempty"`
 
-	// IPBlocks is a list of all IPv4 and IPv6 Ranges that will be available to
+	// IPRanges is a list of all IPv4 and IPv6 Ranges that will be available to
 	// BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of
 	// /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must
 	// not overlap other ranges within the VRF.
-	IPBlocks []string `json:"ip_blocks,omitempty"`
+	IPRanges []string `json:"ip_ranges,omitempty"`
 }
 
 type VRFUpdateRequest struct {
@@ -59,11 +59,11 @@ type VRFUpdateRequest struct {
 	// LocalASN is the ASN of the local network.
 	LocalASN *int `json:"local_asn,omitempty"`
 
-	// IPBlocks is a list of all IPv4 and IPv6 Ranges that will be available to
+	// IPRanges is a list of all IPv4 and IPv6 Ranges that will be available to
 	// BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of
 	// /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must
 	// not overlap other ranges within the VRF.
-	IPBlocks *[]string `json:"ip_blocks,omitempty"`
+	IPRanges *[]string `json:"ip_ranges,omitempty"`
 }
 
 type VRFServiceOp struct {


### PR DESCRIPTION
This PR adds support for the upcoming VRF features:
* vrf.go adds the new service operator for VRF endpoints
* all the new request and response fields for IPReservations, VirtualCircuits, and Gateway are added
* IPReservations had a Request/Remove method pair I’m deprecating in favor of Create/Delete (for future generic’ing)
* IPReservations also learns IPReservationType enum because we have more use of that now (“vrf”+)
* VirtualCircuits also learns VCStatus as an enum type/hint
* packngo.go learns about the new VRF service

VRF features are not generally available. The changes in this PR make some currently "required" (always sent in Create requests) "optional". This does not change the overall experience for existing use-cases. 
Empty values in the modified fields would have angered the EM API before or after these changes.

Fixes #325 

The PR adds support for the following new endpoints:
* [x] `GET /projects/{id}/vrfs`
* [x] `POST /projects/{id}/vrfs`
* [x] `GET /vrfs/{id}`
* [x] `PUT /vrfs/{id}`
* [x] `DELETE /vrfs/{id}`
* [x] `GET /vrfs/{id}/ips`


The following resources have been updated to be aware of new VRF related request and response fields:
* [x] `POST /projects/{id}/ips`
* [x] `POST /interconnections/{id}/ports/{port_id}/virtual-circuits`
* [x] `GET /projects/{id}/ips`
* [x] `GET /ips`
* [x] `GET /interconnections/{id}/ports/{port_id}/virtual-circuits?is_vrf=true`
* [x] `GET /virtual-circuits/{vrf_virtual_circuit_id}`
* [x] `PUT /ips/{id}`

Some resources were indirectly affected, response fields are updated but request fields remain the same, although behavior may be altered conditioned on request values.

* [x] `POST /projects/{id}/metal-gateways`
* [x] `DELETE /metal-gateways/{id}`
* [x] `GET /metal-gateways/{id}`
* [x] `DELETE /ips/{id}`
* [x] `DELETE /virtual-circuits/{vrf_virtual_circuit_id}`

