### PR TITLE
Create organization request required field address

### DIFF
--- a/organizations.go
+++ b/organizations.go
@@ -51,11 +51,12 @@ func (o Organization) String() string {
 
 // OrganizationCreateRequest type used to create an Equinix Metal organization
 type OrganizationCreateRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Website     string `json:"website,omitempty"`
-	Twitter     string `json:"twitter,omitempty"`
-	Logo        string `json:"logo,omitempty"`
+	Name        string  `json:"name"`
+	Description string  `json:"description,omitempty"`
+	Website     string  `json:"website,omitempty"`
+	Twitter     string  `json:"twitter,omitempty"`
+	Logo        string  `json:"logo,omitempty"`
+	Address     Address `json:"address,omitempty"`
 }
 
 func (o OrganizationCreateRequest) String() string {
@@ -64,11 +65,12 @@ func (o OrganizationCreateRequest) String() string {
 
 // OrganizationUpdateRequest type used to update an Equinix Metal organization
 type OrganizationUpdateRequest struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Website     *string `json:"website,omitempty"`
-	Twitter     *string `json:"twitter,omitempty"`
-	Logo        *string `json:"logo,omitempty"`
+	Name        *string  `json:"name,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Website     *string  `json:"website,omitempty"`
+	Twitter     *string  `json:"twitter,omitempty"`
+	Logo        *string  `json:"logo,omitempty"`
+	Address     *Address `json:"address,omitempty"`
 }
 
 func (o OrganizationUpdateRequest) String() string {

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -13,11 +13,19 @@ func TestAccOrgList(t *testing.T) {
 	defer organizationTeardown(c)
 
 	rs := testProjectPrefix + randString8()
+	city := "foo"
+	addr := Address {
+		Address: "test",
+		ZipCode: "12345",
+		Country: "US",
+		City:    &city,
+	}
 	ocr := OrganizationCreateRequest{
 		Name:        rs,
 		Description: "Managed by Packngo.",
 		Website:     "http://example.com",
 		Twitter:     "foo",
+		Address:     addr,
 	}
 	org, _, err := c.Organizations.Create(&ocr)
 	if err != nil {
@@ -55,11 +63,19 @@ func TestAccOrgBasic(t *testing.T) {
 	defer organizationTeardown(c)
 
 	rs := testProjectPrefix + randString8()
+	city := "foo"
+	addr := Address{
+		Address: "test",
+		ZipCode: "12345",
+		Country: "US",
+		City:    &city,
+	}
 	ocr := OrganizationCreateRequest{
 		Name:        rs,
 		Description: "Managed by Packngo.",
 		Website:     "http://example.com",
 		Twitter:     "foo",
+		Address:     addr,
 	}
 	p, _, err := c.Organizations.Create(&ocr)
 	if err != nil {
@@ -71,13 +87,21 @@ func TestAccOrgBasic(t *testing.T) {
 
 	rs = testProjectPrefix + randString8()
 	oDesc := "Managed by Packngo."
-	oWeb := "http://quux.example.com"
-	oTwi := "bar"
+	oWeb  := "http://quux.example.com"
+	oTwi  := "bar"
+	oCity := "bar"
+	oAddr := Address{
+		Address: "test 2",
+		ZipCode: "54321",
+		Country: "bar",
+		City:    &oCity,
+	}
 	pur := OrganizationUpdateRequest{
 		Name:        &rs,
 		Description: &oDesc,
 		Website:     &oWeb,
 		Twitter:     &oTwi,
+		Address:     &oAddr,
 	}
 	org, _, err := c.Organizations.Update(p.ID, &pur)
 	if err != nil {
@@ -114,11 +138,19 @@ func TestAccOrgListPaymentMethods(t *testing.T) {
 	defer organizationTeardown(c)
 
 	rs := testProjectPrefix + randString8()
+	city := "foo"
+	addr := Address{
+		Address: "test",
+		ZipCode: "12345",
+		Country: "US",
+		City:    &city,
+	}
 	ocr := OrganizationCreateRequest{
 		Name:        rs,
 		Description: "Managed by Packngo.",
 		Website:     "http://example.com",
 		Twitter:     "foo",
+		Address:     addr,
 	}
 	org, _, err := c.Organizations.Create(&ocr)
 	if err != nil {

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -17,7 +17,7 @@ func TestAccOrgList(t *testing.T) {
 	addr := Address {
 		Address: "test",
 		ZipCode: "12345",
-		Country: "US",
+		Country: "GB",
 		City:    &city,
 	}
 	ocr := OrganizationCreateRequest{
@@ -67,7 +67,7 @@ func TestAccOrgBasic(t *testing.T) {
 	addr := Address{
 		Address: "test",
 		ZipCode: "12345",
-		Country: "US",
+		Country: "GB",
 		City:    &city,
 	}
 	ocr := OrganizationCreateRequest{
@@ -93,7 +93,7 @@ func TestAccOrgBasic(t *testing.T) {
 	oAddr := Address{
 		Address: "test 2",
 		ZipCode: "54321",
-		Country: "bar",
+		Country: "ES",
 		City:    &oCity,
 	}
 	pur := OrganizationUpdateRequest{
@@ -142,7 +142,7 @@ func TestAccOrgListPaymentMethods(t *testing.T) {
 	addr := Address{
 		Address: "test",
 		ZipCode: "12345",
-		Country: "US",
+		Country: "GB",
 		City:    &city,
 	}
 	ocr := OrganizationCreateRequest{


### PR DESCRIPTION
Added support to field Address in OrganizationCreateRequest and OrganizationUpdateRequest.

Acceptance tests updated to validate address

![image](https://user-images.githubusercontent.com/68897552/167406396-d939ced4-adfa-4335-a8e4-f14c14287eb8.png)

fixes #332