### PR TITLE
Add reservation_pricing field parsing.

### DIFF
--- a/plans.go
+++ b/plans.go
@@ -17,24 +17,52 @@ type planRoot struct {
 
 // Plan represents an Equinix Metal service plan
 type Plan struct {
-	ID                string     `json:"id"`
-	Slug              string     `json:"slug,omitempty"`
-	Name              string     `json:"name,omitempty"`
-	Description       string     `json:"description,omitempty"`
-	Line              string     `json:"line,omitempty"`
-	Legacy            bool       `json:"legacy,omitempty"`
-	Specs             *Specs     `json:"specs,omitempty"`
-	Pricing           *Pricing   `json:"pricing,omitempty"`
-	DeploymentTypes   []string   `json:"deployment_types"`
-	Class             string     `json:"class"`
-	AvailableIn       []Facility `json:"available_in"`
-	AvailableInMetros []Metro    `json:"available_in_metros"`
+	ID                 string              `json:"id"`
+	Slug               string              `json:"slug,omitempty"`
+	Name               string              `json:"name,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	Line               string              `json:"line,omitempty"`
+	Legacy             bool                `json:"legacy,omitempty"`
+	Specs              *Specs              `json:"specs,omitempty"`
+	Pricing            *Pricing            `json:"pricing,omitempty"`
+	DeploymentTypes    []string            `json:"deployment_types"`
+	Class              string              `json:"class"`
+	AvailableIn        []Facility          `json:"available_in"`
+	AvailableInMetros  []Metro             `json:"available_in_metros"`
+	ReservationPricing *ReservationPricing `json:"reservation_pricing,omitempty"`
 
 	Href string `json:"href,omitempty"`
 }
 
 func (p Plan) String() string {
 	return Stringify(p)
+}
+
+// ReservationPricing - The reserved pricing for a plan
+type ReservationPricing struct {
+	OneYear   *OneYear   `json:"one_year"`
+	ThreeYear *ThreeYear `json:"three_year"`
+	SP        *SP        `json:"sp"`
+}
+
+//SP - The Sao Paulo reserved pricing for a plan
+type SP struct {
+	OneYear   *OneYear   `json:"one_year"`
+	ThreeYear *ThreeYear `json:"three_year"`
+}
+
+//OneYear The One year reserved pricing for a plan
+type OneYear struct {
+	Month float32 `json:"month"`
+}
+
+//ThreeYear The One year reserved pricing for a plan
+type ThreeYear struct {
+	Month float32 `json:"month"`
+}
+
+func (r ReservationPricing) String() string {
+	return Stringify(r)
 }
 
 // Specs - the server specs for a plan

--- a/plans.go
+++ b/plans.go
@@ -57,10 +57,16 @@ func (r ReservationPricing) String() string {
 func (r *ReservationPricing) UnmarshalJSON(data []byte) error {
 	var a AnnualReservationPricing
 	var m MetroPricing
-	// Leverage the built in unmarshalling to sort out all the fields
-	json.Unmarshal(data, &a)
-	json.Unmarshal(data, &m)
 
+	// Leverage the built in unmarshalling to sort out all the fields
+	err := json.Unmarshal(data, &a)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		return err
+	}
 	// Remove three_year and one_year from the metropricing object
 	delete(m, "three_year")
 	delete(m, "one_year")

--- a/plans.go
+++ b/plans.go
@@ -1,6 +1,9 @@
 package packngo
 
-import "path"
+import (
+	"encoding/json"
+	"path"
+)
 
 const planBasePath = "/plans"
 
@@ -38,31 +41,44 @@ func (p Plan) String() string {
 	return Stringify(p)
 }
 
+type MetroPricing map[string]AnnualReservationPricing
+
 // ReservationPricing - The reserved pricing for a plan
 type ReservationPricing struct {
-	OneYear   *OneYear   `json:"one_year"`
-	ThreeYear *ThreeYear `json:"three_year"`
-	SP        *SP        `json:"sp"`
-}
-
-//SP - The Sao Paulo reserved pricing for a plan
-type SP struct {
-	OneYear   *OneYear   `json:"one_year"`
-	ThreeYear *ThreeYear `json:"three_year"`
-}
-
-//OneYear The One year reserved pricing for a plan
-type OneYear struct {
-	Month float32 `json:"month"`
-}
-
-//ThreeYear The One year reserved pricing for a plan
-type ThreeYear struct {
-	Month float32 `json:"month"`
+	AnnualReservationPricing
+	Metros MetroPricing
 }
 
 func (r ReservationPricing) String() string {
 	return Stringify(r)
+}
+
+// UnmarshalJSON - Custom unmarshal function to set up the ReservationPricing object
+func (r *ReservationPricing) UnmarshalJSON(data []byte) error {
+	var a AnnualReservationPricing
+	var m MetroPricing
+	// Leverage the built in unmarshalling to sort out all the fields
+	json.Unmarshal(data, &a)
+	json.Unmarshal(data, &m)
+
+	// Remove three_year and one_year from the metropricing object
+	delete(m, "three_year")
+	delete(m, "one_year")
+
+	// Pass the objects to the parent
+	r.Metros = m
+	r.AnnualReservationPricing = a
+
+	return nil
+}
+
+type AnnualReservationPricing struct {
+	OneYear   *Pricing `json:"one_year"`
+	ThreeYear *Pricing `json:"three_year"`
+}
+
+func (m AnnualReservationPricing) String() string {
+	return Stringify(m)
 }
 
 // Specs - the server specs for a plan


### PR DESCRIPTION
Here's an example of what the reservation_pricing fields look like data returned from /plans.

```
{
  "one_year": {
    "month": 1249.2
  },
  "three_year": {
    "month": 1147.9
  },
  "sp": {
    "one_year": {
      "month": 2025.75
    },
    "three_year": {
      "month": 1722
    }
  }
}
```
Or one with more regional variants.
```
{
  "one_year": {
    "month": 1735
  },
  "three_year": {
    "month": 1240
  },
  "ty": {
    "one_year": {
      "month": 2082
    },
    "three_year": {
      "month": 1488
    }
  },
  "tr": {
    "one_year": {
      "month": 1909
    },
    "three_year": {
      "month": 1364
    }
  },
  "hk": {
    "one_year": {
      "month": 2082
    },
    "three_year": {
      "month": 1488
    }
  },
  "sp": {
    "one_year": {
      "month": 2603
    },
    "three_year": {
      "month": 1860
    }
  },
  "pa": {
    "one_year": {
      "month": 1909
    },
    "three_year": {
      "month": 1364
    }
  },
  "ld": {
    "one_year": {
      "month": 1909
    },
    "three_year": {
      "month": 1364
    }
  },
  "am": {
    "one_year": {
      "month": 1909
    },
    "three_year": {
      "month": 1364
    }
  },
  "sg": {
    "one_year": {
      "month": 2082
    },
    "three_year": {
      "month": 1488
    }
  },
  "md": {
    "one_year": {
      "month": 1909
    },
    "three_year": {
      "month": 1364
    }
  },
  "fr": {
    "one_year": {
      "month": 1909
    },
    "three_year": {
      "month": 1364
    }
  },
  "sl": {
    "one_year": {
      "month": 2082
    },
    "three_year": {
      "month": 1488
    }
  },
  "sy": {
    "one_year": {
      "month": 2082
    },
    "three_year": {
      "month": 1488
    }
  }
}
```



Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>