### PR TITLE
allow timestamp null value

### DIFF
--- a/fabric_service_tokens.go
+++ b/fabric_service_tokens.go
@@ -13,7 +13,7 @@ const (
 // FabricServiceToken represents an Equinix Metal metro
 type FabricServiceToken struct {
 	*Href            `json:",inline"`
-	ExpiresAt        Timestamp              `json:"expires_at,omitempty"`
+	ExpiresAt        *Timestamp             `json:"expires_at,omitempty"`
 	ID               string                 `json:"id"`
 	MaxAllowedSpeed  uint64                 `json:"max_allowed_speed,omitempty"`
 	Role             ConnectionPortRole     `json:"role,omitempty"`


### PR DESCRIPTION
Reported in https://github.com/equinix/terraform-provider-equinix/issues/147, API can return null values for the field Timestamp once the token is activated. 

ExpiresAt must be a pointer to allow null Timestamp

Fix https://github.com/packethost/packngo/issues/339