### PR TITLE
docs: rm old TF provider, migrate links to Equinix

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,26 +1,24 @@
 # Owners
 
 This project is governed by [Equinix Metal] and benefits from a community of users that
-collaborate and contribute to its use in Go powered projects, such as the [Equinix Metal
-Terraform provider], [Docker machine driver], Kubernetes drivers for [CSI] and [CCM],
+collaborate and contribute to its use in Go powered projects, such as the [Equinix
+Terraform provider], the [Docker machine driver], the Kubernetes [CCM],
 the [Equinix Metal CLI], and others.
 
 Members of the Equinix Metal Github organization will strive to triage issues in a
 timely manner, see [SUPPORT.md] for details.
 
-See the [packethost/standards glossary] for more details about this file.
+See the [Equinix Labs Glossary] for more details about this file.
 
 ## Maintainers
 
 Maintainers of this repository are defined within the [CODEOWNERS] file.
 
 [Equinix Metal]: https://metal.equinix.com
-[Equinix Metal Terraform provider]: https://github.com/packethost/terraform-provider-packet
-[Docker machine driver]: https://github.com/packethost/docker-machine-driver-packet
-[CSI]: https://github.com/packethost/csi-packet
-[CCM]: https://github.com/packethost/packet-ccm
-[Equinix Metal CLI]: https://github.com/packethost/packet-cli
+[Equinix Terraform provider]: https://github.com/equinix/terraform-provider-equinix
+[Docker machine driver]: https://github.com/equinix/docker-machine-driver-metal
+[CCM]: https://github.com/equinix/cloud-provider-equinix-metal
+[Equinix Metal CLI]: https://github.com/equinix/metal-cli
 [SUPPORT.md]: SUPPORT.md
-[packethost/standards
-glossary]: https://github.com/packethost/standards/blob/master/glossary.md#ownersmd
+[Equinix Labs Glossary]: https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#ownersmd
 [CODEOWNERS]: CODEOWNERS

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # packngo
 
-[![](https://img.shields.io/badge/stability-maintained-green.svg)](https://github.com/packethost/standards/blob/master/maintained-statement.md)
+[![Maintained](https://img.shields.io/badge/stability-maintained-green.svg)](https://github.com/equinix-labs/equinix-labs/blob/main/maintained-statement.md)
 [![Release](https://img.shields.io/github/v/release/packethost/packngo)](https://github.com/packethost/packngo/releases/latest)
 [![GoDoc](https://godoc.org/github.com/packethost/packngo?status.svg)](https://godoc.org/github.com/packethost/packngo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/packethost/packngo)](https://goreportcard.com/report/github.com/packethost/packngo)
@@ -27,7 +27,7 @@ go get github.com/packethost/packngo
 
 ## Stability and Compatibility
 
-This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Equinix Metal and its community - available to use in production environments.
+This repository is [Maintained](https://github.com/equinix-labs/equinix-labs/blob/main/maintained-statement.md) meaning that this software is supported by Equinix Metal and its community - available to use in production environments.
 
 Packngo is currently provided with a major version of [v0](https://blog.golang.org/v2-go-modules). We'll try to avoid breaking changes to this library, but they will certainly happen as we work towards a stable v1 library. See [CHANGELOG.md](CHANGELOG.md) for details on the latest additions, removals, fixes, and breaking changes.
 
@@ -67,7 +67,7 @@ func main() {
 
 ```
 
-This library is used by the official [terraform-provider-packet](https://github.com/packethost/terraform-provider-packet).
+This library is used by the official [terraform-provider-equinix](https://github.com/equinix/terraform-provider-equinix).
 
 You can also learn a lot from the `*_test.go` sources. Almost all out tests touch the Equinix Metal API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
 


### PR DESCRIPTION
Only docs changed.

Mention the Terraform provider which is maintained instead of one which
has a flashing "unsupported" banner. (And I've checked that [it uses packngo](https://github.com/equinix/terraform-provider-equinix/blob/84d062c2f5f2f5587bd80debeb516d81bcef1fb7/go.mod#L15)).

Use phrasing "Kubernetes CCM" instead of "Kubernetes driver for CCM"
because neither the Kubernetes official docs nor CCM docs refer to it
as a "driver".

Remove link to CSI, since it has been sunset.

Bypass the redirects in all remaining `packethost/*` links.