### PR TITLE
added operating_system field to reinstall action

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -443,8 +443,9 @@ type DeviceDeleteRequest struct {
 	Force bool `json:"force_delete"`
 }
 type DeviceReinstallFields struct {
-	PreserveData    bool `json:"preserve_data,omitempty"`
-	DeprovisionFast bool `json:"deprovision_fast,omitempty"`
+	OperatingSystem  string `json:"operating_system,omitempty"`
+	PreserveData     bool   `json:"preserve_data,omitempty"`
+	DeprovisionFast  bool   `json:"deprovision_fast,omitempty"`
 }
 
 type DeviceReinstallRequest struct {

--- a/devices_test.go
+++ b/devices_test.go
@@ -170,7 +170,10 @@ func TestAccDeviceReinstall(t *testing.T) {
 
 	waitDeviceActive(t, c, dID)
 
-	rf := DeviceReinstallFields{DeprovisionFast: true}
+	rf := DeviceReinstallFields{
+		DeprovisionFast: true,
+		OperatingSystem: "ubuntu_20_04",
+	}
 
 	_, err = c.Devices.Reinstall(dID, &rf)
 	if err != nil {


### PR DESCRIPTION
OperatingSystem must be specified as a body parameter to reinstall with a new OS

Fix https://github.com/packethost/packngo/issues/343