### PR TITLE
Available Addresses call doesn't utilize CIDR

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -376,7 +376,7 @@ func (i *ProjectIPServiceOp) AvailableAddresses(ipReservationID string, r *Avail
 	}
 
 	opts := &GetOptions{}
-	opts.Filter("cidr", strconv.Itoa(r.CIDR))
+	opts = opts.Filter("cidr", strconv.Itoa(r.CIDR))
 
 	endpointPath := path.Join(ipBasePath, ipReservationID, "available")
 	apiPathQuery := opts.WithQuery(endpointPath)


### PR DESCRIPTION
The opts.Filter() call returns a new object instead of an existing. Since the underlying object isn't being modified, we must capture the output of Filter.

This API call doesn't work otherwise.