### PR TITLE
introduce PACKET_API_URL env variable

### DIFF
--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,5 +47,4 @@ func Test_Deserialization(t *testing.T) {
 	assert.Equal(t, "10.144.51.11", volumes[0].IPs[1].String())
 	assert.Equal(t, 10, volumes[0].Capacity.Size)
 	assert.Equal(t, "gb", volumes[0].Capacity.Unit)
-
 }

--- a/packngo_test.go
+++ b/packngo_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	apiURLEnvVar      = "PACKET_API_URL"
 	packngoAccTestVar = "PACKNGO_TEST_ACTUAL_API"
 	testProjectPrefix = "PACKNGO_TEST_DELME_2d768716_"
 	testFacilityVar   = "PACKNGO_TEST_FACILITY"
@@ -98,7 +97,6 @@ func setupWithProject(t *testing.T) (*Client, string, func()) {
 		}
 		stopRecord()
 	}
-
 }
 
 func skipUnlessAcceptanceTestsAllowed(t *testing.T) {
@@ -156,9 +154,9 @@ func setup(t *testing.T) (*Client, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	apiURL := os.Getenv(apiURLEnvVar)
+	apiURL := os.Getenv(urlEnvVar)
 	if apiURL == "" {
-		apiURL = baseURL
+		apiURL = defaultURL
 	}
 	r, stopRecord := testRecorder(t, name, mode)
 	httpClient := http.DefaultClient
@@ -216,7 +214,6 @@ func TestAccInvalidCredentials(t *testing.T) {
 	if !matched {
 		t.Fatalf("Unexpected error string: %s", expectedErr)
 	}
-
 }
 
 func Test_dumpDeprecation(t *testing.T) {


### PR DESCRIPTION
Just as `PACKET_AUTH_TOKEN` can be used today to set an authentication token, `PACKET_API_URL` is being added to allow developers and users to set custom API URL targets. Some applications may already provide overrides via configuration files and environment. This environment variable will provide flexibility where applications did offer this.

The existing default value has been preserved for `NewClient`, `NewClientWithAuth`, and `NewClientWithBaseURL`. The former can now take advantage of `PACKET_API_URL`.

Fixes #322 