### PR TITLE
feat: add error handling for application/problem+json responses

### DIFF
--- a/packngo.go
+++ b/packngo.go
@@ -452,7 +452,10 @@ func checkResponse(r *http.Response) error {
 	}
 
 	ct := r.Header.Get("Content-Type")
-	if !strings.HasPrefix(ct, expectedAPIContentTypePrefix) {
+	if strings.HasPrefix(ct, "application/problem+json") {
+		errorResponse.SingleError = string(data)
+		return errorResponse
+	} else if !strings.HasPrefix(ct, expectedAPIContentTypePrefix) {
 		errorResponse.SingleError = fmt.Sprintf("Unexpected Content-Type %s with status %s", ct, r.Status)
 		return errorResponse
 	}


### PR DESCRIPTION
While the Equinix Metal API does not return this API header natively, tools such as Spotlight Prism can proxy the API and they may return this standard error content-type.