### PR TITLE
feat: add Device.SOS field

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -79,6 +79,7 @@ type Device struct {
 	SSHKeys             []SSHKey               `json:"ssh_keys,omitempty"`
 	ShortID             string                 `json:"short_id,omitempty"`
 	SwitchUUID          string                 `json:"switch_uuid,omitempty"`
+	SOS                 string                 `json:"sos,omitempty"`
 }
 
 type NetworkInfo struct {


### PR DESCRIPTION
Adds the new `device` `sos` field.

https://deploy.equinix.com/developers/api/metal#tag/Devices/operation/createDevice (201 response field)