### PR TITLE
feat: add deprecation comment to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/equinix/equinix-sdk-go instead.
 module github.com/packethost/packngo
 
 require (


### PR DESCRIPTION
Added a comment linking to equinix-sdk-go, based on https://go.dev/ref/mod#go-mod-file-module-deprecation